### PR TITLE
Set correct height on backstage and application menu button

### DIFF
--- a/Fluent/Themes/Office2010/Controls/ApplicationMenu.xaml
+++ b/Fluent/Themes/Office2010/Controls/ApplicationMenu.xaml
@@ -22,7 +22,7 @@
                             Margin="0">
                 <Border x:Name="PART_ButtonBorder"
                         MinWidth="56"
-                        Height="23"
+                        Height="24"
                         CornerRadius="2,2,0,0"
                         Background="{TemplateBinding Background}">
                     <Border x:Name="border1"

--- a/Fluent/Themes/Office2010/Controls/Backstage.xaml
+++ b/Fluent/Themes/Office2010/Controls/Backstage.xaml
@@ -10,7 +10,7 @@
                             Margin="0">
                 <Border x:Name="PART_ButtonBorder"
                         MinWidth="56"
-                        Height="23"
+                        Height="24"
                         CornerRadius="2,2,0,0"
                         Background="{TemplateBinding Background}">
                     <Border x:Name="border1"


### PR DESCRIPTION
Height was incorrect in the Office 2010 theme for the backstage and application menu button.
