### PR TITLE
Simplified the RibbonTabItem template for the office 2010 theme.

### DIFF
--- a/Fluent/Controls/Primitives/RibbonTabItemBorder.cs
+++ b/Fluent/Controls/Primitives/RibbonTabItemBorder.cs
@@ -1,0 +1,329 @@
+﻿using System;
+using System.ComponentModel;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+
+namespace Fluent.Controls.Primitives
+{
+    /// <summary>
+    /// A custom border element for use in the <see cref="RibbonTabItem"/> control
+    /// template.
+    /// </summary>
+    public class RibbonTabItemBorder : Decorator
+    {
+        #region "Constructors"
+
+        /// <summary>
+        /// Initializes instance members of the <see cref="RibbonTabItemBorder"/> class.
+        /// </summary>
+        public RibbonTabItemBorder()
+        {
+
+        }
+
+        #endregion
+
+        #region "Properties"
+
+
+        #region CornerRadius
+
+        /// <summary>
+        /// Identifies the <see cref="CornerRadius"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty CornerRadiusProperty = DependencyProperty.Register(
+            "CornerRadius",
+            typeof(double),
+            typeof(RibbonTabItemBorder),
+            new FrameworkPropertyMetadata(
+                0.0,
+                FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender));
+
+        /// <summary>
+        /// Gets or sets the CornerRadius property. This is a dependency property.
+        /// </summary>
+        /// <value>
+        ///
+        /// </value>
+        [Bindable(true)]
+        public double CornerRadius
+        {
+            get { return (double)GetValue(CornerRadiusProperty); }
+            set { SetValue(CornerRadiusProperty, value); }
+        }
+
+        #endregion
+
+        #region BorderBrush
+
+        /// <summary>
+        /// Identifies the <see cref="BorderBrush"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty BorderBrushProperty = DependencyProperty.Register(
+            "BorderBrush",
+            typeof(Brush),
+            typeof(RibbonTabItemBorder),
+            new FrameworkPropertyMetadata(
+                null,
+                FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.SubPropertiesDoNotAffectRender));
+
+        /// <summary>
+        /// Gets or sets the BorderBrush property. This is a dependency property.
+        /// </summary>
+        /// <value>
+        ///
+        /// </value>
+        [Bindable(true)]
+        public Brush BorderBrush
+        {
+            get { return (Brush)GetValue(BorderBrushProperty); }
+            set { SetValue(BorderBrushProperty, value); }
+        }
+
+        #endregion
+
+        #region BorderThickness
+
+        /// <summary>
+        /// Identifies the <see cref="BorderThickness"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty BorderThicknessProperty = DependencyProperty.Register(
+            "BorderThickness",
+            typeof(double),
+            typeof(RibbonTabItemBorder),
+            new FrameworkPropertyMetadata(
+                0.0,
+                FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender),
+            value =>
+            {
+                // you can't have a thickness lest than 0
+                // we don't coerce we validate.
+                var thickness = (double)value;
+                return thickness >= 0;
+            });
+
+        /// <summary>
+        /// Gets or sets the BorderThickness property. This is a dependency property.
+        /// </summary>
+        /// <value>
+        ///
+        /// </value>
+        [Bindable(true)]
+        public double BorderThickness
+        {
+            get { return (double)GetValue(BorderThicknessProperty); }
+            set { SetValue(BorderThicknessProperty, value); }
+        }
+
+        #endregion
+
+        #region Padding
+
+        /// <summary>
+        /// Identifies the <see cref="Padding"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty PaddingProperty = DependencyProperty.Register(
+            "Padding",
+            typeof(Thickness),
+            typeof(RibbonTabItemBorder),
+            new FrameworkPropertyMetadata(
+                new Thickness(),
+                FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender));
+
+        /// <summary>
+        /// Gets or sets the Padding property. This is a dependency property.
+        /// </summary>
+        /// <value>
+        ///
+        /// </value>
+        [Bindable(true)]
+        public Thickness Padding
+        {
+            get { return (Thickness)GetValue(PaddingProperty); }
+            set { SetValue(PaddingProperty, value); }
+        }
+
+        #endregion
+
+        #region Background
+
+        /// <summary>
+        /// Identifies the <see cref="Background"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty BackgroundProperty = DependencyProperty.Register(
+            "Background",
+            typeof(Brush),
+            typeof(RibbonTabItemBorder),
+            new FrameworkPropertyMetadata(
+                null,
+                FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.SubPropertiesDoNotAffectRender));
+
+        /// <summary>
+        /// Gets or sets the Background property. This is a dependency property.
+        /// </summary>
+        /// <value>
+        ///
+        /// </value>
+        [Bindable(true)]
+        public Brush Background
+        {
+            get { return (Brush)GetValue(BackgroundProperty); }
+            set { SetValue(BackgroundProperty, value); }
+        }
+
+        #endregion
+
+        #endregion
+
+        #region "Methods"
+
+        protected override Size MeasureOverride(Size constraint)
+        {
+            var child = this.Child;
+            var borderThickness = this.BorderThickness;
+            var padding = this.Padding;
+
+            // prepare the child available space
+            var reservedWidth = (padding.Left + padding.Right) + (borderThickness*2);
+            var reservedHeight = (padding.Top + padding.Bottom) + (borderThickness*2);
+            if (child == null)
+            {
+                return new Size(reservedWidth, reservedHeight);
+            }
+
+            var availableWidth = Math.Max(0.0, constraint.Width - reservedWidth);
+            var availableHeight = Math.Max(0.0, constraint.Height - reservedHeight);
+
+            child.Measure(new Size(availableWidth, availableHeight));
+            var desiredSize = child.DesiredSize;
+            return new Size(desiredSize.Width + reservedWidth, desiredSize.Height + reservedHeight);
+        }
+
+        protected override Size ArrangeOverride(Size arrangeSize)
+        {
+            var child = this.Child;
+
+            if (child != null)
+            {
+                var childRect = new Rect(arrangeSize);
+                var borderThickness = this.BorderThickness;
+                var padding = this.Padding;
+                var reservedWidth = (padding.Left + padding.Right) + (borderThickness*2);
+                var reservedHeight = (padding.Top + padding.Bottom) + (borderThickness*2);
+
+                childRect.Width = Math.Max(0.0, arrangeSize.Width - reservedWidth);
+                childRect.Height = Math.Max(0.0, arrangeSize.Height - reservedHeight);
+
+                childRect.X = padding.Left + borderThickness;
+                childRect.Y = padding.Top + borderThickness;
+
+                child.Arrange(childRect);
+            }
+
+            return arrangeSize;
+        }
+
+        protected override void OnRender(DrawingContext dc)
+        {
+            var background = this.Background;
+            if (background != null)
+            {
+                var geometry = this.GetBorderGeometry(RenderSize, true);
+                dc.DrawGeometry(background, new Pen(null, BorderThickness), geometry);
+            }
+
+
+            var brush = BorderBrush;
+            var borderThickness = BorderThickness;
+
+            if (brush != null && borderThickness > 0)
+            {
+                var borderGeometry = GetBorderGeometry(this.RenderSize, false);
+                dc.DrawGeometry(this.Background, new Pen(brush, borderThickness), borderGeometry);
+            }
+        }
+
+        private Geometry GetBorderGeometry(Size renderSize, bool isFilled)
+        {
+            var geomtry = new StreamGeometry();
+            var borderThickness = BorderThickness*0.5;
+            var cornerRadius = CornerRadius;
+
+            bool isCornerRadiusIncluded = cornerRadius > 0;
+
+            using (var ctx = geomtry.Open())
+            {
+                if (isCornerRadiusIncluded)
+                {
+                    // we start from the bottom right corner.
+                    var p0 = new Point(0,
+                        renderSize.Height - (isFilled ? 0 : borderThickness));
+
+                    ctx.BeginFigure(p0, isFilled, false);
+
+                    var p1 = new Point(p0.X + cornerRadius, p0.Y - cornerRadius);
+                    var cp1 = new Point(p1.X, renderSize.Height - borderThickness);
+                    ctx.QuadraticBezierTo(cp1, p1, true, false);
+
+                    var p2 = new Point(p1.X, cornerRadius + borderThickness);
+                    ctx.LineTo(p2, true, true);
+
+                    var p3 = new Point(
+                        p2.X + cornerRadius,
+                        borderThickness);
+                    var cp3 = new Point(p2.X, borderThickness);
+                    ctx.QuadraticBezierTo(cp3, p3, true, false);
+
+                    var p4 = new Point(
+                        renderSize.Width - (cornerRadius*2) - (isFilled ? 0 : borderThickness),
+                        borderThickness);
+                    ctx.LineTo(p4, true, true);
+
+                    var p5 = new Point(
+                        p4.X + cornerRadius,
+                        p4.Y + cornerRadius);
+                    var cp5 = new Point(renderSize.Width - borderThickness - cornerRadius,
+                        borderThickness);
+                    ctx.QuadraticBezierTo(cp5, p5, true, false);
+
+                    var p6 = new Point(
+                        p5.X,
+                        renderSize.Height - (cornerRadius + (isFilled ? 0 : borderThickness)));
+                    ctx.LineTo(p6, true, true);
+
+                    var p7 = new Point(p6.X + cornerRadius, p6.Y + cornerRadius);
+
+                    if (isFilled)
+                    {
+                        p7.X -= borderThickness;
+                    }
+
+                    p7.X += borderThickness;
+
+                    var cp7 = new Point(p6.X, renderSize.Height - borderThickness);
+                    ctx.QuadraticBezierTo(cp7, p7, true, false);
+                }
+                else
+                {
+                    var renderRect = new Rect(borderThickness,
+                        borderThickness,
+                        renderSize.Width - (borderThickness*2),
+                        renderSize.Height - borderThickness);
+
+                    ctx.BeginFigure(renderRect.BottomLeft, isFilled, false);
+                    ctx.LineTo(renderRect.TopLeft, true, true);
+                    ctx.LineTo(renderRect.TopRight, true, true);
+                    ctx.LineTo(renderRect.BottomRight, true, false);
+                }
+
+
+            }
+
+            geomtry.Freeze();
+            return geomtry;
+        }
+
+        #endregion
+    }
+}

--- a/Fluent/Controls/Primitives/RibbonTabItemBorder.cs
+++ b/Fluent/Controls/Primitives/RibbonTabItemBorder.cs
@@ -10,6 +10,10 @@ namespace Fluent.Controls.Primitives
     /// A custom border element for use in the <see cref="RibbonTabItem"/> control
     /// template.
     /// </summary>
+    /// <remarks>
+    /// The border will render a different geometry based on the value of <see cref="RenderInnerBorder"/> property
+    /// being true or false.
+    /// </remarks>
     public class RibbonTabItemBorder : Decorator
     {
         #region "Fields"
@@ -53,11 +57,8 @@ namespace Fluent.Controls.Primitives
                 }));
 
         /// <summary>
-        /// Gets or sets the CornerRadius property. This is a dependency property.
+        /// Gets or sets a value that indicates the roundness of corners. This is a dependency property.
         /// </summary>
-        /// <value>
-        ///
-        /// </value>
         [Bindable(true)]
         public double CornerRadius
         {
@@ -83,9 +84,6 @@ namespace Fluent.Controls.Primitives
         /// <summary>
         /// Gets or sets the RenderInnerBorder property. This is a dependency property.
         /// </summary>
-        /// <value>
-        ///
-        /// </value>
         [Bindable(true)]
         public bool RenderInnerBorder
         {
@@ -114,11 +112,9 @@ namespace Fluent.Controls.Primitives
                 }));
 
         /// <summary>
-        /// Gets or sets the BorderBrush property. This is a dependency property.
+        /// Gets or sets the <see cref="Brush"/> used to fill the outer border region. 
+        /// This is a dependency property.
         /// </summary>
-        /// <value>
-        ///
-        /// </value>
         [Bindable(true)]
         public Brush BorderBrush
         {
@@ -147,11 +143,8 @@ namespace Fluent.Controls.Primitives
                 }));
 
         /// <summary>
-        /// Gets or sets the InnerBorderBrush property. This is a dependency property.
+        /// Gets or sets the <see cref="Brush"/> used to fill the inner border region. This is a dependency property.
         /// </summary>
-        /// <value>
-        ///
-        /// </value>
         [Bindable(true)]
         public Brush InnerBorderBrush
         {
@@ -189,11 +182,9 @@ namespace Fluent.Controls.Primitives
             });
 
         /// <summary>
-        /// Gets or sets the BorderThickness property. This is a dependency property.
+        /// Gets or sets a value that indicates how thick the outer and inner borders are.
+        /// This is a dependency property.
         /// </summary>
-        /// <value>
-        ///
-        /// </value>
         [Bindable(true)]
         public double BorderThickness
         {
@@ -219,9 +210,6 @@ namespace Fluent.Controls.Primitives
         /// <summary>
         /// Gets or sets the Padding property. This is a dependency property.
         /// </summary>
-        /// <value>
-        ///
-        /// </value>
         [Bindable(true)]
         public Thickness Padding
         {
@@ -245,11 +233,9 @@ namespace Fluent.Controls.Primitives
                 FrameworkPropertyMetadataOptions.AffectsRender));
 
         /// <summary>
-        /// Gets or sets the Background property. This is a dependency property.
+        /// Gets or sets <see cref="Brush"/> used to fill the area within the border. 
+        /// This is a dependency property.
         /// </summary>
-        /// <value>
-        ///
-        /// </value>
         [Bindable(true)]
         public Brush Background
         {
@@ -311,6 +297,9 @@ namespace Fluent.Controls.Primitives
             return arrangeSize;
         }
 
+        /// <summary>
+        /// Will ensure that the caches geometries are invalidated during the next render pass.
+        /// </summary>
         private void InvalidateGeometries()
         {
             EnsureRenderers();
@@ -318,6 +307,9 @@ namespace Fluent.Controls.Primitives
             _mouserOverRenderer.InvalidateCache();
         }
 
+        /// <summary>
+        /// Ensures that the <see cref="IRenderer"/> instances are created.
+        /// </summary>
         private void EnsureRenderers()
         {
             if (_normalRenderer == null)
@@ -384,6 +376,12 @@ namespace Fluent.Controls.Primitives
             private Geometry _cachedInnerBorderGeometry;
             private Geometry _cachedBackgroundGeometry;
 
+            /// <summary>
+            /// when the tab item is not selected and the mouse is over it,
+            /// if we don't exclude the following value from the rendering rect
+            /// our border will overlap with the horizontal border of the ribbon
+            /// tab control
+            /// </summary>
             private const double BOTTOM_PADDING = 1.0;
 
             #endregion
@@ -440,7 +438,7 @@ namespace Fluent.Controls.Primitives
                 }
             }
 
-            private void EnsureOuterBorderGeometry(Size rs, double ht, double cr)
+            private void EnsureOuterBorderGeometry(Size rs /* render size */, double ht /* half thickness */, double cr /* corner radius*/)
             {
                 if (_cachedOuterBorderGeometry != null)
                     return;
@@ -503,7 +501,6 @@ namespace Fluent.Controls.Primitives
 
                         if (isInnerBorder)
                         {
-                            //var actualOuterCornerRadius = corner radius + (border thickness / 2);
                             radius = Math.Max(0.0, cornerRadius - (t / 2) - (t / 2));
 
                             var p2 = new Point(rect.Left, rect.Top + radius);
@@ -747,9 +744,9 @@ namespace Fluent.Controls.Primitives
 
                 // I found it very hard to construct a background geometry
                 // that doesn't overlap the border geometry, the issue was
-                // always the bottom left/right corner radius.
+                // always the bottom left & right corner radius.
                 // so what I am doing is constructing the background geometry based
-                // on the border geometry and stretching to fill the remaining
+                // on the border geometry and stretching it to fill the remaining
                 // bottom space.
                 return isBackground ? ApplyTransform(geometry, bt, renderSize) : geometry;
             }
@@ -760,7 +757,6 @@ namespace Fluent.Controls.Primitives
                 pathGeometry.AddGeometry(geometry);
 
                 var hbt = bt * 0.5;
-                //var scaleY = ((hbt * 100) / renderSize.Height) / 100;
                 var scaleY = hbt / renderSize.Height;
                 pathGeometry.Transform = new ScaleTransform(1, scaleY + 1, renderSize.Width * 0.5, 0);
                 pathGeometry.Freeze();

--- a/Fluent/Controls/Primitives/RibbonTabItemBorder.cs
+++ b/Fluent/Controls/Primitives/RibbonTabItemBorder.cs
@@ -12,6 +12,15 @@ namespace Fluent.Controls.Primitives
     /// </summary>
     public class RibbonTabItemBorder : Decorator
     {
+        #region "Fields"
+
+        private Pen _cachedInnerBorderPen;
+        private Pen _cachedOuterBorderPen;
+        private IRenderer _mouserOverRenderer;
+        private IRenderer _normalRenderer;
+
+        #endregion
+
         #region "Constructors"
 
         /// <summary>
@@ -19,13 +28,11 @@ namespace Fluent.Controls.Primitives
         /// </summary>
         public RibbonTabItemBorder()
         {
-
         }
 
         #endregion
 
         #region "Properties"
-
 
         #region CornerRadius
 
@@ -38,7 +45,12 @@ namespace Fluent.Controls.Primitives
             typeof(RibbonTabItemBorder),
             new FrameworkPropertyMetadata(
                 0.0,
-                FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender));
+                FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender,
+                (o, args) =>
+                {
+                    var border = (RibbonTabItemBorder)o;
+                    border.InvalidateGeometries();
+                }));
 
         /// <summary>
         /// Gets or sets the CornerRadius property. This is a dependency property.
@@ -55,6 +67,34 @@ namespace Fluent.Controls.Primitives
 
         #endregion
 
+        #region RenderInnerBorder
+
+        /// <summary>
+        /// Identifies the <see cref="RenderInnerBorder"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty RenderInnerBorderProperty = DependencyProperty.Register(
+            "RenderInnerBorder",
+            typeof(bool),
+            typeof(RibbonTabItemBorder),
+            new FrameworkPropertyMetadata(
+                false,
+                FrameworkPropertyMetadataOptions.AffectsRender));
+
+        /// <summary>
+        /// Gets or sets the RenderInnerBorder property. This is a dependency property.
+        /// </summary>
+        /// <value>
+        ///
+        /// </value>
+        [Bindable(true)]
+        public bool RenderInnerBorder
+        {
+            get { return (bool)GetValue(RenderInnerBorderProperty); }
+            set { SetValue(RenderInnerBorderProperty, value); }
+        }
+
+        #endregion
+
         #region BorderBrush
 
         /// <summary>
@@ -66,7 +106,12 @@ namespace Fluent.Controls.Primitives
             typeof(RibbonTabItemBorder),
             new FrameworkPropertyMetadata(
                 null,
-                FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.SubPropertiesDoNotAffectRender));
+                FrameworkPropertyMetadataOptions.AffectsRender,
+                (o, args) =>
+                {
+                    var border = (RibbonTabItemBorder)o;
+                    border._cachedOuterBorderPen = null;
+                }));
 
         /// <summary>
         /// Gets or sets the BorderBrush property. This is a dependency property.
@@ -83,6 +128,39 @@ namespace Fluent.Controls.Primitives
 
         #endregion
 
+        #region InnerBorderBrush
+
+        /// <summary>
+        /// Identifies the <see cref="InnerBorderBrush"/> dependency property.
+        /// </summary>
+        public static readonly DependencyProperty InnerBorderBrushProperty = DependencyProperty.Register(
+            "InnerBorderBrush",
+            typeof(Brush),
+            typeof(RibbonTabItemBorder),
+            new FrameworkPropertyMetadata(
+                null,
+                FrameworkPropertyMetadataOptions.AffectsRender,
+                (o, args) =>
+                {
+                    var border = (RibbonTabItemBorder)o;
+                    border._cachedInnerBorderPen = null;
+                }));
+
+        /// <summary>
+        /// Gets or sets the InnerBorderBrush property. This is a dependency property.
+        /// </summary>
+        /// <value>
+        ///
+        /// </value>
+        [Bindable(true)]
+        public Brush InnerBorderBrush
+        {
+            get { return (Brush)GetValue(InnerBorderBrushProperty); }
+            set { SetValue(InnerBorderBrushProperty, value); }
+        }
+
+        #endregion
+
         #region BorderThickness
 
         /// <summary>
@@ -94,7 +172,14 @@ namespace Fluent.Controls.Primitives
             typeof(RibbonTabItemBorder),
             new FrameworkPropertyMetadata(
                 0.0,
-                FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender),
+                FrameworkPropertyMetadataOptions.AffectsMeasure | FrameworkPropertyMetadataOptions.AffectsRender,
+                (o, args) =>
+                {
+                    var border = (RibbonTabItemBorder)o;
+                    border._cachedOuterBorderPen = null;
+                    border._cachedInnerBorderPen = null;
+                    border.InvalidateGeometries();
+                }),
             value =>
             {
                 // you can't have a thickness lest than 0
@@ -157,7 +242,7 @@ namespace Fluent.Controls.Primitives
             typeof(RibbonTabItemBorder),
             new FrameworkPropertyMetadata(
                 null,
-                FrameworkPropertyMetadataOptions.AffectsRender | FrameworkPropertyMetadataOptions.SubPropertiesDoNotAffectRender));
+                FrameworkPropertyMetadataOptions.AffectsRender));
 
         /// <summary>
         /// Gets or sets the Background property. This is a dependency property.
@@ -185,8 +270,8 @@ namespace Fluent.Controls.Primitives
             var padding = this.Padding;
 
             // prepare the child available space
-            var reservedWidth = (padding.Left + padding.Right) + (borderThickness*2);
-            var reservedHeight = (padding.Top + padding.Bottom) + (borderThickness*2);
+            var reservedWidth = (padding.Left + padding.Right) + (borderThickness * 2);
+            var reservedHeight = (padding.Top + padding.Bottom) + (borderThickness * 2);
             if (child == null)
             {
                 return new Size(reservedWidth, reservedHeight);
@@ -209,8 +294,8 @@ namespace Fluent.Controls.Primitives
                 var childRect = new Rect(arrangeSize);
                 var borderThickness = this.BorderThickness;
                 var padding = this.Padding;
-                var reservedWidth = (padding.Left + padding.Right) + (borderThickness*2);
-                var reservedHeight = (padding.Top + padding.Bottom) + (borderThickness*2);
+                var reservedWidth = (padding.Left + padding.Right) + (borderThickness * 2);
+                var reservedHeight = (padding.Top + padding.Bottom) + (borderThickness * 2);
 
                 childRect.Width = Math.Max(0.0, arrangeSize.Width - reservedWidth);
                 childRect.Height = Math.Max(0.0, arrangeSize.Height - reservedHeight);
@@ -221,107 +306,460 @@ namespace Fluent.Controls.Primitives
                 child.Arrange(childRect);
             }
 
+
+
             return arrangeSize;
+        }
+
+        private void InvalidateGeometries()
+        {
+            EnsureRenderers();
+            _normalRenderer.InvalidateCache();
+            _mouserOverRenderer.InvalidateCache();
+        }
+
+        private void EnsureRenderers()
+        {
+            if (_normalRenderer == null)
+            {
+                _normalRenderer = new NormalRenderer(this);
+            }
+
+            if (_mouserOverRenderer == null)
+            {
+                _mouserOverRenderer = new MouseOverRenderer(this);
+            }
         }
 
         protected override void OnRender(DrawingContext dc)
         {
-            var background = this.Background;
-            if (background != null)
+            IRenderer currentRenderer;
+            EnsureOuterBorderPen();
+
+            if (RenderInnerBorder)
             {
-                var geometry = this.GetBorderGeometry(RenderSize, true);
-                dc.DrawGeometry(background, new Pen(null, BorderThickness), geometry);
+                EnsureInnerBorderPen();
+                currentRenderer = _mouserOverRenderer;
+            }
+            else
+            {
+                currentRenderer = _normalRenderer;
             }
 
+            currentRenderer.Render(dc);
+        }
 
-            var brush = BorderBrush;
-            var borderThickness = BorderThickness;
-
-            if (brush != null && borderThickness > 0)
+        private void EnsureOuterBorderPen()
+        {
+            if (_cachedOuterBorderPen == null)
             {
-                var borderGeometry = GetBorderGeometry(this.RenderSize, false);
-                dc.DrawGeometry(this.Background, new Pen(brush, borderThickness), borderGeometry);
+                _cachedOuterBorderPen = new Pen(this.BorderBrush, this.BorderThickness);
             }
         }
 
-        private Geometry GetBorderGeometry(Size renderSize, bool isFilled)
+        private void EnsureInnerBorderPen()
         {
-            var geomtry = new StreamGeometry();
-            var borderThickness = BorderThickness*0.5;
-            var cornerRadius = CornerRadius;
-
-            bool isCornerRadiusIncluded = cornerRadius > 0;
-
-            using (var ctx = geomtry.Open())
+            if (_cachedInnerBorderPen == null)
             {
-                if (isCornerRadiusIncluded)
-                {
-                    // we start from the bottom right corner.
-                    var p0 = new Point(0,
-                        renderSize.Height - (isFilled ? 0 : borderThickness));
+                _cachedInnerBorderPen = new Pen(this.InnerBorderBrush, this.BorderThickness);
+            }
+        }
 
-                    ctx.BeginFigure(p0, isFilled, false);
+        #endregion
 
-                    var p1 = new Point(p0.X + cornerRadius, p0.Y - cornerRadius);
-                    var cp1 = new Point(p1.X, renderSize.Height - borderThickness);
-                    ctx.QuadraticBezierTo(cp1, p1, true, false);
+        #region "Private Types"
 
-                    var p2 = new Point(p1.X, cornerRadius + borderThickness);
-                    ctx.LineTo(p2, true, true);
+        private interface IRenderer
+        {
+            void Render(DrawingContext dc);
+            void InvalidateCache();
+        }
 
-                    var p3 = new Point(
-                        p2.X + cornerRadius,
-                        borderThickness);
-                    var cp3 = new Point(p2.X, borderThickness);
-                    ctx.QuadraticBezierTo(cp3, p3, true, false);
+        private class MouseOverRenderer : IRenderer
+        {
+            #region "Fields"
 
-                    var p4 = new Point(
-                        renderSize.Width - (cornerRadius*2) - (isFilled ? 0 : borderThickness),
-                        borderThickness);
-                    ctx.LineTo(p4, true, true);
+            private readonly RibbonTabItemBorder _border;
+            private Geometry _cachedOuterBorderGeometry;
+            private Geometry _cachedInnerBorderGeometry;
+            private Geometry _cachedBackgroundGeometry;
 
-                    var p5 = new Point(
-                        p4.X + cornerRadius,
-                        p4.Y + cornerRadius);
-                    var cp5 = new Point(renderSize.Width - borderThickness - cornerRadius,
-                        borderThickness);
-                    ctx.QuadraticBezierTo(cp5, p5, true, false);
+            #endregion
 
-                    var p6 = new Point(
-                        p5.X,
-                        renderSize.Height - (cornerRadius + (isFilled ? 0 : borderThickness)));
-                    ctx.LineTo(p6, true, true);
+            #region "Constructors"
 
-                    var p7 = new Point(p6.X + cornerRadius, p6.Y + cornerRadius);
-
-                    if (isFilled)
-                    {
-                        p7.X -= borderThickness;
-                    }
-
-                    p7.X += borderThickness;
-
-                    var cp7 = new Point(p6.X, renderSize.Height - borderThickness);
-                    ctx.QuadraticBezierTo(cp7, p7, true, false);
-                }
-                else
-                {
-                    var renderRect = new Rect(borderThickness,
-                        borderThickness,
-                        renderSize.Width - (borderThickness*2),
-                        renderSize.Height - borderThickness);
-
-                    ctx.BeginFigure(renderRect.BottomLeft, isFilled, false);
-                    ctx.LineTo(renderRect.TopLeft, true, true);
-                    ctx.LineTo(renderRect.TopRight, true, true);
-                    ctx.LineTo(renderRect.BottomRight, true, false);
-                }
-
-
+            /// <summary>
+            /// Initializes instance members of the <see cref="MouseOverRenderer"/> class.
+            /// </summary>
+            public MouseOverRenderer(RibbonTabItemBorder border)
+            {
+                _border = border;
             }
 
-            geomtry.Freeze();
-            return geomtry;
+            #endregion
+
+            #region "Methods"
+
+            public void InvalidateCache()
+            {
+                _cachedBackgroundGeometry = null;
+                _cachedInnerBorderGeometry = null;
+                _cachedOuterBorderGeometry = null;
+            }
+
+            public void Render(DrawingContext dc)
+            {
+                var cr = _border.CornerRadius;
+                var rs = _border.RenderSize;
+                var t = _border.BorderThickness;
+
+                // we start by rendering the background
+                var background = _border.Background;
+                if (background != null)
+                {
+                    EnsureBackgroundGeometry(rs, t, cr);
+                    dc.DrawGeometry(background, null, _cachedBackgroundGeometry);
+                }
+
+                // render the inner border
+                var innerBorderPen = _border._cachedInnerBorderPen;
+                if (innerBorderPen != null)
+                {
+                    EnsureInnerBorderGeometry(rs, t, cr);
+                    dc.DrawGeometry(null, innerBorderPen, _cachedInnerBorderGeometry);
+                }
+
+                // render the outer border
+                var outerBorderPen = _border._cachedOuterBorderPen;
+                if (outerBorderPen != null)
+                {
+                    EnsureOuterBorderGeometry(rs, t * 0.5, cr);
+                    dc.DrawGeometry(null, outerBorderPen, _cachedOuterBorderGeometry);
+                }
+            }
+
+            private void EnsureOuterBorderGeometry(Size rs, double ht, double cr)
+            {
+                if (_cachedOuterBorderGeometry != null)
+                    return;
+
+                var rect = new Rect(
+                    ht + cr,
+                    ht,
+                    rs.Width - ((ht * 2) + (cr * 2)),
+                    rs.Height - ht);
+                _cachedOuterBorderGeometry = this.ConstructGeometry(rect, cr, false);
+            }
+
+            private void EnsureBackgroundGeometry(Size rs /*render size*/, double t /* thickness*/, double cr /* corner radius */)
+            {
+                var ht = t * 0.5;
+                // render the background
+                var bgRect = new Rect(
+                    ht + cr + t + ht,
+                    ht + t + ht,
+                    Math.Max(0.0, rs.Width - ((ht * 2) + (cr * 2) + ((t + ht) * 2))),
+                    Math.Max(0.0, rs.Height - (ht * 2) - t));
+
+                _cachedBackgroundGeometry = this.ConstructGeometry(bgRect, GetInnerBorderRadius(cr, t), true);
+            }
+
+            private void EnsureInnerBorderGeometry(Size rs, double t, double cr)
+            {
+                double ht = t * 0.5;
+                var innerBorderRect = new Rect(
+                    ht + cr + t,
+                    ht + t,
+                    Math.Max(0.0, rs.Width - ((ht * 2) + (cr * 2) + (t * 2))),
+                    Math.Max(0.0, rs.Height - ht - t));
+
+                _cachedInnerBorderGeometry = this.ConstructGeometry(innerBorderRect, cr, true);
+            }
+
+            private Geometry ConstructGeometry(Rect rect, double cornerRadius, bool isInnerBorder)
+            {
+                var geometry = new StreamGeometry();
+                const bool isStroked = true;
+                const bool isLargeArc = false;
+                const bool isSmoothJoin = false;
+                var t = _border.BorderThickness;
+
+                using (var ctx = geometry.Open())
+                {
+                    var p0 = new Point(rect.Left, rect.Bottom);
+                    ctx.BeginFigure(p0, true /* is filled */, false);
+
+                    if (cornerRadius > 0)
+                    {
+                        double radius;
+
+                        if (isInnerBorder)
+                        {
+                            //var actualOuterCornerRadius = corner radius + (border thickness / 2);
+                            radius = Math.Max(0.0, cornerRadius - (t / 2) - (t / 2));
+
+                            var p2 = new Point(rect.Left, rect.Top + radius);
+                            ctx.LineTo(p2, isStroked, isSmoothJoin);
+
+                            if (radius > 0.0)
+                            {
+                                var p3 = new Point(rect.Left + radius, rect.Top);
+                                ctx.ArcTo(p3,
+                                    new Size(radius, radius),
+                                    0,
+                                    isLargeArc,
+                                    SweepDirection.Clockwise,
+                                    isStroked,
+                                    isSmoothJoin);
+                            }
+                        }
+                        else
+                        {
+                            radius = cornerRadius;
+
+                            var p2 = new Point(rect.Left, rect.Top + radius);
+                            ctx.LineTo(p2, isStroked, isSmoothJoin);
+
+                            if (radius > 0)
+                            {
+                                var p3 = new Point(rect.Left + radius, rect.Top);
+                                ctx.ArcTo(p3,
+                                    new Size(radius, radius),
+                                    0,
+                                    isLargeArc,
+                                    SweepDirection.Clockwise,
+                                    isStroked,
+                                    isSmoothJoin);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        var p2 = new Point(rect.Left, rect.Top);
+                        ctx.LineTo(p2, isStroked, isSmoothJoin);
+                    }
+
+                    if (cornerRadius > 0)
+                    {
+                        double radius;
+
+                        if (isInnerBorder)
+                        {
+                            radius = Math.Max(0.0, cornerRadius - (t / 2) - (t / 2));
+
+                            var p2 = new Point(rect.Right - radius, rect.Top);
+                            ctx.LineTo(p2, isStroked, isSmoothJoin);
+
+                            if (radius > 0)
+                            {
+                                var p3 = new Point(rect.Right, rect.Top + radius);
+                                ctx.ArcTo(p3,
+                                    new Size(radius, radius),
+                                    0,
+                                    isLargeArc,
+                                    SweepDirection.Clockwise,
+                                    isStroked,
+                                    isSmoothJoin);
+                            }
+                        }
+                        else
+                        {
+                            radius = cornerRadius;
+
+                            var p4 = new Point(rect.Right - radius, rect.Top);
+                            ctx.LineTo(p4, isStroked, isSmoothJoin);
+
+                            if (radius > 0)
+                            {
+                                var p5 = new Point(rect.Right, rect.Top + radius);
+                                ctx.ArcTo(p5,
+                                    new Size(radius, radius),
+                                    0,
+                                    isLargeArc,
+                                    SweepDirection.Clockwise,
+                                    isStroked,
+                                    isSmoothJoin);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        var p4 = new Point(rect.Right, rect.Top);
+                        ctx.LineTo(p4, isStroked, false);
+                    }
+
+                    var p6 = new Point(rect.Right, rect.Bottom);
+                    ctx.LineTo(p6, isStroked, false);
+                }
+
+                geometry.Freeze();
+                return geometry;
+            }
+
+            private double GetInnerBorderRadius(double cornerRadius, double borderThickness)
+            {
+                // very helpful: http://stackoverflow.com/questions/2932146/math-problem-determine-the-corner-radius-of-an-inner-border-based-on-outer-corn
+                // as well as the main answer here: https://social.msdn.microsoft.com/Forums/vstudio/en-US/d51311e2-80c1-44cd-a5cf-f463abe444f0/cornerradius-and-border-width
+                return Math.Max(0.0, cornerRadius - (borderThickness / 2) - (borderThickness / 2));
+            }
+
+            #endregion
+        }
+
+        private class NormalRenderer : IRenderer
+        {
+            #region "Methods"
+
+            private readonly RibbonTabItemBorder _border;
+            private Geometry _cachedBackgroundGeometry;
+            private Geometry _cachedBorderGeometry;
+
+            #endregion
+
+            #region "Constructors"
+
+            /// <summary>
+            /// Initializes instance members of the <see cref="NormalRenderer"/> class.
+            /// </summary>
+            internal NormalRenderer(RibbonTabItemBorder border)
+            {
+                _border = border;
+            }
+
+            #endregion
+
+            #region "Methods"
+
+            public void InvalidateCache()
+            {
+                // they will be re-generated on the render pass
+                _cachedBackgroundGeometry = null;
+                _cachedBorderGeometry = null;
+            }
+
+            public void Render(DrawingContext dc)
+            {
+                var brush = _border.Background;
+                if (brush != null)
+                {
+                    EnsureBackgroundGeometry();
+                    dc.DrawGeometry(brush, null, _cachedBackgroundGeometry);
+                }
+
+                if (_border.BorderBrush != null)
+                {
+                    EnsureBorderGeometry();
+                    dc.DrawGeometry(null, _border._cachedOuterBorderPen, _cachedBorderGeometry);
+                }
+            }
+
+            private void EnsureBackgroundGeometry()
+            {
+                if (_cachedBackgroundGeometry == null)
+                {
+                    _cachedBackgroundGeometry = GenerateGeometry(_border.RenderSize, _border.CornerRadius, true);
+                }
+            }
+
+            private void EnsureBorderGeometry()
+            {
+                if (_cachedBorderGeometry == null)
+                {
+                    _cachedBorderGeometry = GenerateGeometry(_border.RenderSize, _border.CornerRadius, false);
+                }
+            }
+
+            private Geometry GenerateGeometry(Size renderSize, double cr /* corner Radius*/, bool isBackground)
+            {
+                var bt = _border.BorderThickness;
+                var hbt = bt * 0.5;
+                const bool isLargeArc = false;
+                const bool isSmoothJoin = false;
+                var rect = new Rect(hbt, hbt, renderSize.Width - bt, renderSize.Height - bt);
+                var radiusSize = new Size(cr, cr);
+                var geometry = new StreamGeometry();
+                const bool isStroked = true;
+                var hasCornerRadius = cr > 0;
+
+                using (var ctx = geometry.Open())
+                {
+                    var p0 = new Point(rect.Left - (hasCornerRadius ? hbt : 0),
+                        rect.Bottom + (isBackground || hasCornerRadius ? 0 : hbt));
+                    ctx.BeginFigure(p0, true /* is filled */, false);
+                    var p1 = new Point(rect.Left + cr, rect.Bottom - cr);
+
+                    if (hasCornerRadius)
+                    {
+                        var cp1 = new Point(rect.Left + cr, rect.Bottom);
+                        ctx.QuadraticBezierTo(cp1, p1, isStroked, false);
+                    }
+
+                    var p2 = new Point(rect.Left + cr, rect.Top + cr);
+                    ctx.LineTo(p2, isStroked, false);
+
+                    if (hasCornerRadius)
+                    {
+                        var p3 = new Point(rect.Left + (cr * 2), rect.Top);
+                        ctx.ArcTo(p3,
+                            radiusSize,
+                            0,
+                            isLargeArc,
+                            SweepDirection.Clockwise,
+                            true,
+                            isSmoothJoin);
+                    }
+
+                    var p4 = new Point(rect.Right - (cr * 2), rect.Top);
+                    ctx.LineTo(p4, isStroked, false);
+
+                    if (hasCornerRadius)
+                    {
+                        var p5 = new Point(rect.Right - cr, rect.Top + cr);
+                        ctx.ArcTo(p5,
+                            radiusSize,
+                            0,
+                            isLargeArc,
+                            SweepDirection.Clockwise,
+                            true,
+                            isSmoothJoin);
+                    }
+
+                    var p6 = new Point(rect.Right - cr, rect.Bottom - cr + (isBackground || hasCornerRadius ? 0 : hbt));
+                    ctx.LineTo(p6, isStroked, false);
+
+                    if (hasCornerRadius)
+                    {
+                        var p7 = new Point(rect.Right + hbt, rect.Bottom);
+                        var cp7 = new Point(rect.Right - cr, rect.Bottom);
+                        ctx.QuadraticBezierTo(cp7, p7, isStroked, false);
+                    }
+                }
+
+                geometry.Freeze();
+
+                // I found it very hard to construct a background geometry
+                // that doesn't overlap the border geometry, the issue was
+                // always the bottom left/right corner radius.
+                // so what I am doing is constructing the background geometry based
+                // on the border geometry and stretching to fill the remaining
+                // bottom space.
+                return isBackground ? ApplyTransform(geometry, bt, renderSize) : geometry;
+            }
+
+            private static Geometry ApplyTransform(Geometry geometry, double bt, Size renderSize)
+            {
+                var pathGeometry = new PathGeometry();
+                pathGeometry.AddGeometry(geometry);
+
+                var hbt = bt * 0.5;
+                //var scaleY = ((hbt * 100) / renderSize.Height) / 100;
+                var scaleY = hbt / renderSize.Height;
+                pathGeometry.Transform = new ScaleTransform(1, scaleY + 1, renderSize.Width * 0.5, 0);
+                pathGeometry.Freeze();
+                return pathGeometry;
+            }
+
+            #endregion
         }
 
         #endregion

--- a/Fluent/Controls/Primitives/RibbonTabItemBorder.cs
+++ b/Fluent/Controls/Primitives/RibbonTabItemBorder.cs
@@ -306,7 +306,7 @@ namespace Fluent.Controls.Primitives
                 child.Arrange(childRect);
             }
 
-
+            this.InvalidateGeometries();
 
             return arrangeSize;
         }
@@ -384,6 +384,8 @@ namespace Fluent.Controls.Primitives
             private Geometry _cachedInnerBorderGeometry;
             private Geometry _cachedBackgroundGeometry;
 
+            private const double BOTTOM_PADDING = 1.0;
+
             #endregion
 
             #region "Constructors"
@@ -447,31 +449,37 @@ namespace Fluent.Controls.Primitives
                     ht + cr,
                     ht,
                     rs.Width - ((ht * 2) + (cr * 2)),
-                    rs.Height - ht);
+                    rs.Height - ht - BOTTOM_PADDING);
                 _cachedOuterBorderGeometry = this.ConstructGeometry(rect, cr, false);
             }
 
             private void EnsureBackgroundGeometry(Size rs /*render size*/, double t /* thickness*/, double cr /* corner radius */)
             {
+                if (_cachedBackgroundGeometry != null)
+                    return;
+
                 var ht = t * 0.5;
                 // render the background
                 var bgRect = new Rect(
                     ht + cr + t + ht,
                     ht + t + ht,
                     Math.Max(0.0, rs.Width - ((ht * 2) + (cr * 2) + ((t + ht) * 2))),
-                    Math.Max(0.0, rs.Height - (ht * 2) - t));
+                    Math.Max(0.0, rs.Height - (ht * 2) - t - BOTTOM_PADDING));
 
                 _cachedBackgroundGeometry = this.ConstructGeometry(bgRect, GetInnerBorderRadius(cr, t), true);
             }
 
             private void EnsureInnerBorderGeometry(Size rs, double t, double cr)
             {
+                if (_cachedInnerBorderGeometry != null)
+                    return;
+
                 double ht = t * 0.5;
                 var innerBorderRect = new Rect(
                     ht + cr + t,
                     ht + t,
                     Math.Max(0.0, rs.Width - ((ht * 2) + (cr * 2) + (t * 2))),
-                    Math.Max(0.0, rs.Height - ht - t));
+                    Math.Max(0.0, rs.Height - ht - t - BOTTOM_PADDING));
 
                 _cachedInnerBorderGeometry = this.ConstructGeometry(innerBorderRect, cr, true);
             }

--- a/Fluent/Controls/Primitives/SingleCellGrid.cs
+++ b/Fluent/Controls/Primitives/SingleCellGrid.cs
@@ -1,0 +1,45 @@
+﻿namespace Fluent.Controls.Primitives
+{
+    using System.Windows;
+    using System.Windows.Controls;
+
+    /// <summary>
+    /// A custom panel that will arrange all of its children in the same
+    /// space.
+    /// </summary>
+    public class SingleCellGrid : Panel
+    {
+        protected override Size MeasureOverride(Size availableSize)
+        {
+            var desiredWidth = 0.0;
+            var desiredHeight = 0.0;
+
+            foreach (UIElement child in this.InternalChildren)
+            {
+                child.Measure(availableSize);
+                var desiredSize = child.DesiredSize;
+                if (desiredSize.Width > desiredWidth)
+                {
+                    desiredWidth = desiredSize.Width;
+                }
+
+                if (desiredSize.Height > desiredHeight)
+                {
+                    desiredHeight = desiredSize.Height;
+                }
+            }
+
+            return new Size(desiredWidth, desiredHeight);
+        }
+
+        protected override Size ArrangeOverride(Size finalSize)
+        {
+            var rect = new Rect(finalSize);
+            foreach (UIElement child in this.InternalChildren)
+            {
+                child.Arrange(rect);
+            }
+            return finalSize;
+        }
+    }
+}

--- a/Fluent/Fluent dotNET 4.0.csproj
+++ b/Fluent/Fluent dotNET 4.0.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Controls\ComboBox.cs" />
     <Compile Include="Controls\ContextMenu.cs" />
     <Compile Include="Controls\Primitives\RibbonTabItemBorder.cs" />
+    <Compile Include="Controls\Primitives\SingleCellGrid.cs" />
     <Compile Include="Internal\UIHelper.cs" />
     <Compile Include="Services\ContextMenuService.cs" />
     <Compile Include="Converters\ApplicationMenuRightContentExtractorConverter.cs" />

--- a/Fluent/Fluent dotNET 4.0.csproj
+++ b/Fluent/Fluent dotNET 4.0.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Controls\ColorGallery.cs" />
     <Compile Include="Controls\ComboBox.cs" />
     <Compile Include="Controls\ContextMenu.cs" />
+    <Compile Include="Controls\Primitives\RibbonTabItemBorder.cs" />
     <Compile Include="Internal\UIHelper.cs" />
     <Compile Include="Services\ContextMenuService.cs" />
     <Compile Include="Converters\ApplicationMenuRightContentExtractorConverter.cs" />

--- a/Fluent/Fluent dotNET 4.5.csproj
+++ b/Fluent/Fluent dotNET 4.5.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Controls\ColorGallery.cs" />
     <Compile Include="Controls\ComboBox.cs" />
     <Compile Include="Controls\ContextMenu.cs" />
+    <Compile Include="Controls\Primitives\RibbonTabItemBorder.cs" />
     <Compile Include="Internal\UIHelper.cs" />
     <Compile Include="Services\ContextMenuService.cs" />
     <Compile Include="Converters\ApplicationMenuRightContentExtractorConverter.cs" />

--- a/Fluent/Fluent dotNET 4.5.csproj
+++ b/Fluent/Fluent dotNET 4.5.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Controls\ComboBox.cs" />
     <Compile Include="Controls\ContextMenu.cs" />
     <Compile Include="Controls\Primitives\RibbonTabItemBorder.cs" />
+    <Compile Include="Controls\Primitives\SingleCellGrid.cs" />
     <Compile Include="Internal\UIHelper.cs" />
     <Compile Include="Services\ContextMenuService.cs" />
     <Compile Include="Converters\ApplicationMenuRightContentExtractorConverter.cs" />

--- a/Fluent/Themes/Office2010/Controls/RibbonContextualTabGroup.xaml
+++ b/Fluent/Themes/Office2010/Controls/RibbonContextualTabGroup.xaml
@@ -5,21 +5,16 @@
                     xmlns:internal="clr-namespace:Fluent.Internal">
     <Style x:Key="RibbonContextualTabGroupStyle"
            TargetType="{x:Type Fluent:RibbonContextualTabGroup}">
-        <Setter Property="Template"
-                Value="{DynamicResource RibbonContextualTabGroupControlTemplate}" />
-        <Setter Property="Width"
-                Value="Auto" />
-        <Setter Property="HorizontalAlignment"
-                Value="Stretch" />
-        <Setter Property="Focusable"
-                Value="False" />
+        <Setter Property="Template" Value="{DynamicResource RibbonContextualTabGroupControlTemplate}" />
+        <Setter Property="Width" Value="Auto" />
+        <Setter Property="HorizontalAlignment" Value="Stretch" />
+        <Setter Property="Focusable" Value="False" />
     </Style>
 
-    <ControlTemplate x:Key="RibbonContextualTabGroupControlTemplate"
-                     TargetType="{x:Type Fluent:RibbonContextualTabGroup}">
+    <ControlTemplate x:Key="RibbonContextualTabGroupControlTemplate" TargetType="{x:Type Fluent:RibbonContextualTabGroup}">
         <Border x:Name="rootBorder"
                 Visibility="{TemplateBinding InnerVisibility}"
-                Margin="2,0,0,0"
+                Margin="1,0"
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Stretch"
                 Width="Auto"
@@ -27,12 +22,9 @@
                 BorderThickness="1,0"
                 Background="{DynamicResource TransparentBrush}">
             <Border.BorderBrush>
-                <LinearGradientBrush EndPoint="0.5,1"
-                                     StartPoint="0.5,0">
-                    <GradientStop Color="#F2FFFFFF"
-                                  Offset="0" />
-                    <GradientStop Color="#CCFFFFFF"
-                                  Offset="1" />
+                <LinearGradientBrush EndPoint="0.5,1" StartPoint="0.5,0">
+                    <GradientStop Color="#F2FFFFFF" Offset="0" />
+                    <GradientStop Color="#CCFFFFFF" Offset="1" />
                 </LinearGradientBrush>
             </Border.BorderBrush>
             <Border BorderBrush="{TemplateBinding BorderBrush}"
@@ -51,16 +43,11 @@
                                Height="Auto"
                                StrokeThickness="0">
                         <Rectangle.OpacityMask>
-                            <LinearGradientBrush EndPoint="0.5,1"
-                                                 StartPoint="0.5,0">
-                                <GradientStop Color="Black"
-                                              Offset="0" />
-                                <GradientStop Color="#59000000"
-                                              Offset="1" />
-                                <GradientStop Color="Black"
-                                              Offset="0.16" />
-                                <GradientStop Color="#99000000"
-                                              Offset="0.161" />
+                            <LinearGradientBrush EndPoint="0.5,1" StartPoint="0.5,0">
+                                <GradientStop Color="Black" Offset="0" />
+                                <GradientStop Color="#59000000" Offset="1" />
+                                <GradientStop Color="Black" Offset="0.16" />
+                                <GradientStop Color="#99000000" Offset="0.161" />
                             </LinearGradientBrush>
                         </Rectangle.OpacityMask>
                     </Rectangle>
@@ -71,16 +58,11 @@
                                Height="Auto"
                                Fill="#3FD2D2D2">
                         <Rectangle.OpacityMask>
-                            <LinearGradientBrush EndPoint="0.5,1"
-                                                 StartPoint="0.5,0">
-                                <GradientStop Color="Black"
-                                              Offset="0" />
-                                <GradientStop Color="#7F000000"
-                                              Offset="1" />
-                                <GradientStop Color="Black"
-                                              Offset="0.16" />
-                                <GradientStop Color="#B2000000"
-                                              Offset="0.161" />
+                            <LinearGradientBrush EndPoint="0.5,1" StartPoint="0.5,0">
+                                <GradientStop Color="Black" Offset="0" />
+                                <GradientStop Color="#7F000000" Offset="1" />
+                                <GradientStop Color="Black" Offset="0.16" />
+                                <GradientStop Color="#B2000000" Offset="0.161" />
                             </LinearGradientBrush>
                         </Rectangle.OpacityMask>
                     </Rectangle>
@@ -111,13 +93,5 @@
                 </Grid>
             </Border>
         </Border>
-        <ControlTemplate.Triggers>
-            <Trigger Property="IsWindowMaximized"
-                     Value="True">
-                <Setter Property="Margin"
-                        TargetName="rootBorder"
-                        Value="2,0,0,-0.1" />
-            </Trigger>
-        </ControlTemplate.Triggers>
     </ControlTemplate>
 </ResourceDictionary>

--- a/Fluent/Themes/Office2010/Controls/RibbonTabItem.xaml
+++ b/Fluent/Themes/Office2010/Controls/RibbonTabItem.xaml
@@ -198,10 +198,7 @@
                                     Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderBrush}" />
                         </MultiTrigger>
                         <Trigger Property="Group" Value="{x:Null}">
-                            <!--<Setter Property="Visibility" TargetName="border3" Value="Collapsed" />
-                            <Setter Property="Margin" TargetName="separatorGrid" Value="-1,0,0,1" />
-                            <Setter Property="Visibility" TargetName="border_Copy3" Value="Collapsed" />
-                            <Setter Property="Visibility" TargetName="rectangle3" Value="Collapsed" />-->
+                            <Setter Property="Visibility" TargetName="border3" Value="Collapsed" />
                         </Trigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
@@ -211,24 +208,6 @@
                             <Setter TargetName="Border" Property="RenderInnerBorder" Value="True" />
                             <Setter TargetName="Border" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderBrush}" />
                         </MultiTrigger>
-                        <!--<MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="Selector.IsSelected" Value="True" />
-                                <Condition Property="IsMinimized" Value="True" />
-                            </MultiTrigger.Conditions>
-                            <Setter TargetName="Border"
-                                    Property="RenderInnerBorder"
-                                    Value="True" />
-                            <Setter TargetName="Border"
-                                    Property="BorderBrush"
-                                    Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderBrush}" />
-                            <Setter TargetName="Border"
-                                    Property="Background"
-                                    Value="{DynamicResource ActiveTabBackgroundBrush}" />
-                            <Setter TargetName="Border"
-                                    Property="RenderInnerBorder"
-                                    Value="True" />
-                        </MultiTrigger>-->
                         <Trigger Property="IsSeparatorVisible" Value="True">
                             <Setter Property="Visibility"
                                     TargetName="separatorGrid"

--- a/Fluent/Themes/Office2010/Controls/RibbonTabItem.xaml
+++ b/Fluent/Themes/Office2010/Controls/RibbonTabItem.xaml
@@ -5,6 +5,50 @@
                     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                     mc:Ignorable="d">
+    
+    <Style x:Key="RibbonTabItemSeparatorStyle" TargetType="Separator">
+        <Setter Property="OverridesDefaultStyle" Value="True" />
+        <Setter Property="Width" Value="2" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Separator">
+                    <pr:SingleCellGrid>
+                        <Rectangle x:Name="separatorRectangle1"
+                                       Fill="{DynamicResource RibbonTopBorderBrush}"
+                                       Stroke="{DynamicResource RibbonTopBorderBrush}"
+                                       Margin="0,0,1,0"
+                                       HorizontalAlignment="Right"
+                                       Width="1"
+                                       Opacity="1"
+                                       Visibility="Visible">
+                            <Rectangle.OpacityMask>
+                                <LinearGradientBrush EndPoint="0.5,1" StartPoint="0.5,0">
+                                    <GradientStop Color="#00000000" Offset="0" />
+                                    <GradientStop Color="#E5FFFFFF" Offset="0.382" />
+                                </LinearGradientBrush>
+                            </Rectangle.OpacityMask>
+                        </Rectangle>
+                        <Rectangle x:Name="separatorRectangle2"
+                                       Fill="{DynamicResource ActiveTabBackgroundBrush}"
+                                       Stroke="{DynamicResource ActiveTabBackgroundBrush}"
+                                       HorizontalAlignment="Right"
+                                       Margin="0"
+                                       Width="1"
+                                       Opacity="1"
+                                       Visibility="Visible">
+                            <Rectangle.OpacityMask>
+                                <LinearGradientBrush EndPoint="0.5,1" StartPoint="0.5,0">
+                                    <GradientStop Color="#00000000" Offset="0" />
+                                    <GradientStop Color="#BFFFFFFF" Offset="0.329" />
+                                </LinearGradientBrush>
+                            </Rectangle.OpacityMask>
+                        </Rectangle>
+                    </pr:SingleCellGrid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    
     <Style x:Key="RibbonTabItemStyle"
            TargetType="{x:Type Fluent:RibbonTabItem}">
         <Style.Triggers>
@@ -26,7 +70,7 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Fluent:RibbonTabItem}">
-                    <Grid Margin="0,7,0,0">
+                    <pr:SingleCellGrid Margin="0,7,0,0">
                         <pr:RibbonTabItemBorder x:Name="Border"
                                                 Background="Transparent"
                                                 BorderThickness="1"
@@ -48,42 +92,11 @@
                                                   Height="Auto" />
                             </Border>
                         </pr:RibbonTabItemBorder>
-                        <Grid x:Name="separatorGrid"
-                              Visibility="Collapsed"
-                              HorizontalAlignment="Right"
-                              Margin="0,0,-1,0"
-                              Width="2">
-                            <Rectangle x:Name="separatorRectangle1"
-                                       Fill="{DynamicResource RibbonTopBorderBrush}"
-                                       Stroke="{DynamicResource RibbonTopBorderBrush}"
-                                       Margin="0,0,1,0"
-                                       HorizontalAlignment="Right"
-                                       Width="1"
-                                       Opacity="1"
-                                       Visibility="Visible">
-                                <Rectangle.OpacityMask>
-                                    <LinearGradientBrush EndPoint="0.5,1" StartPoint="0.5,0">
-                                        <GradientStop Color="#00000000" Offset="0" />
-                                        <GradientStop Color="#E5FFFFFF" Offset="0.382" />
-                                    </LinearGradientBrush>
-                                </Rectangle.OpacityMask>
-                            </Rectangle>
-                            <Rectangle x:Name="separatorRectangle2"
-                                       Fill="{DynamicResource ActiveTabBackgroundBrush}"
-                                       Stroke="{DynamicResource ActiveTabBackgroundBrush}"
-                                       HorizontalAlignment="Right"
-                                       Margin="0"
-                                       Width="1"
-                                       Opacity="1"
-                                       Visibility="Visible">
-                                <Rectangle.OpacityMask>
-                                    <LinearGradientBrush EndPoint="0.5,1" StartPoint="0.5,0">
-                                        <GradientStop Color="#00000000" Offset="0" />
-                                        <GradientStop Color="#BFFFFFFF" Offset="0.329" />
-                                    </LinearGradientBrush>
-                                </Rectangle.OpacityMask>
-                            </Rectangle>
-                        </Grid>
+                        <Separator x:Name="separatorGrid"
+                                   Visibility="Collapsed"
+                                   HorizontalAlignment="Right"
+                                   Style="{StaticResource RibbonTabItemSeparatorStyle}"
+                                   Margin="0,0,-1,0" />
 
                         <Border x:Name="border3"
                                 BorderThickness="1,0"
@@ -132,7 +145,7 @@
                                 </Border>
                             </Border>
                         </Border>
-                    </Grid>
+                    </pr:SingleCellGrid>
                     
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsEnabled" Value="False">

--- a/Fluent/Themes/Office2010/Controls/RibbonTabItem.xaml
+++ b/Fluent/Themes/Office2010/Controls/RibbonTabItem.xaml
@@ -79,7 +79,7 @@
                                                 CornerRadius="2">
                             <Border x:Name="PART_ContentContainer"
                                     HorizontalAlignment="Stretch"
-                                    Margin="6,2,4,0"
+                                    Margin="6,2,6,0"
                                     VerticalAlignment="Stretch"
                                     Padding="15,0,0,0">
                                 <ContentPresenter x:Name="contentPresenter"

--- a/Fluent/Themes/Office2010/Controls/RibbonTabItem.xaml
+++ b/Fluent/Themes/Office2010/Controls/RibbonTabItem.xaml
@@ -37,8 +37,7 @@
                                     HorizontalAlignment="Stretch"
                                     Margin="6,2,4,0"
                                     VerticalAlignment="Stretch"
-                                    Padding="15,0,0,0"
-                                    Grid.ColumnSpan="1">
+                                    Padding="15,0,0,0">
                                 <ContentPresenter x:Name="contentPresenter"
                                                   AutomationProperties.Name="{TemplateBinding Header}"
                                                   AutomationProperties.AutomationId="{TemplateBinding Name}"
@@ -87,8 +86,8 @@
                         </Grid>
 
                         <Border x:Name="border3"
-                                Margin="1,0"
                                 BorderThickness="1,0"
+                                Margin="1,0,1,1"
                                 Grid.ColumnSpan="2">
                             <Border.BorderBrush>
                                 <LinearGradientBrush EndPoint="0.5,1"
@@ -108,9 +107,7 @@
                                         <GradientStop Color="#00000000" Offset="0.981" />
                                     </LinearGradientBrush>
                                 </Border.OpacityMask>
-                                <Border Background="{Binding Group.Background, RelativeSource={RelativeSource TemplatedParent}}"
-                                        BorderThickness="0"
-                                        Margin="0">
+                                <Border Background="{Binding Group.Background, RelativeSource={RelativeSource TemplatedParent}}">
                                     <Border.OpacityMask>
                                         <LinearGradientBrush EndPoint="0.5,1"
                                                              StartPoint="0.5,0">
@@ -121,8 +118,7 @@
                                         </LinearGradientBrush>
                                     </Border.OpacityMask>
                                     <Rectangle x:Name="rectangle4"
-                                               Fill="#3FD2D2D2"
-                                               StrokeThickness="0">
+                                               Fill="#3FD2D2D2">
                                         <Rectangle.OpacityMask>
                                             <LinearGradientBrush EndPoint="0.5,1"
                                                                  StartPoint="0.5,0">
@@ -142,8 +138,8 @@
                         <Trigger Property="IsEnabled" Value="False">
                             <Setter Property="Opacity" Value="0.5" />
                         </Trigger>
-
-
+                        
+                        <!-- Contextual Tabs Triggers -->
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
                                 <Condition Property="HasRightGroupBorder" Value="False" />
@@ -152,7 +148,7 @@
                             <Setter Property="BorderThickness" TargetName="border3" Value="1,0,0,0" />
                             <Setter Property="BorderThickness" TargetName="border4" Value="1,0,0,0" />
                             <Setter Property="Margin" TargetName="rectangle4" Value="0" />
-                            <Setter Property="Margin" TargetName="border3" Value="1,0,0,0" />
+                            <Setter Property="Margin" TargetName="border3" Value="1,0,0,1" />
                         </MultiTrigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
@@ -162,7 +158,7 @@
                             <Setter Property="BorderThickness" TargetName="border4" Value="0,0,1,0" />
                             <Setter Property="BorderThickness" TargetName="border3" Value="0,0,1,0" />
                             <Setter Property="Margin" TargetName="rectangle4" Value="0" />
-                            <Setter Property="Margin" TargetName="border3" Value="0,0,1,0" />
+                            <Setter Property="Margin" TargetName="border3" Value="0,0,1,1" />
                         </MultiTrigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
@@ -172,8 +168,9 @@
                             <Setter Property="BorderThickness" TargetName="border4" Value="0,0,0,0" />
                             <Setter Property="BorderThickness" TargetName="border3" Value="0,0,0,0" />
                             <Setter Property="Margin" TargetName="rectangle4" Value="0" />
-                            <Setter Property="Margin" TargetName="border3" Value="0" />
+                            <Setter Property="Margin" TargetName="border3" Value="0,0,0,1" />
                         </MultiTrigger>
+                        
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
                                 <Condition Property="IsMouseOver" Value="True" />
@@ -214,6 +211,24 @@
                             <Setter TargetName="Border" Property="RenderInnerBorder" Value="True" />
                             <Setter TargetName="Border" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderBrush}" />
                         </MultiTrigger>
+                        <!--<MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="Selector.IsSelected" Value="True" />
+                                <Condition Property="IsMinimized" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="Border"
+                                    Property="RenderInnerBorder"
+                                    Value="True" />
+                            <Setter TargetName="Border"
+                                    Property="BorderBrush"
+                                    Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderBrush}" />
+                            <Setter TargetName="Border"
+                                    Property="Background"
+                                    Value="{DynamicResource ActiveTabBackgroundBrush}" />
+                            <Setter TargetName="Border"
+                                    Property="RenderInnerBorder"
+                                    Value="True" />
+                        </MultiTrigger>-->
                         <Trigger Property="IsSeparatorVisible" Value="True">
                             <Setter Property="Visibility"
                                     TargetName="separatorGrid"

--- a/Fluent/Themes/Office2010/Controls/RibbonTabItem.xaml
+++ b/Fluent/Themes/Office2010/Controls/RibbonTabItem.xaml
@@ -174,8 +174,6 @@
                             <Setter Property="Margin" TargetName="rectangle4" Value="0" />
                             <Setter Property="Margin" TargetName="border3" Value="0" />
                         </MultiTrigger>
-
-
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
                                 <Condition Property="IsMouseOver" Value="True" />
@@ -208,6 +206,14 @@
                             <Setter Property="Visibility" TargetName="border_Copy3" Value="Collapsed" />
                             <Setter Property="Visibility" TargetName="rectangle3" Value="Collapsed" />-->
                         </Trigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="IsMouseOver" Value="True" />
+                                <Condition Property="IsMinimized" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="Border" Property="RenderInnerBorder" Value="True" />
+                            <Setter TargetName="Border" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderBrush}" />
+                        </MultiTrigger>
                         <Trigger Property="IsSeparatorVisible" Value="True">
                             <Setter Property="Visibility"
                                     TargetName="separatorGrid"

--- a/Fluent/Themes/Office2010/Controls/RibbonTabItem.xaml
+++ b/Fluent/Themes/Office2010/Controls/RibbonTabItem.xaml
@@ -1,43 +1,93 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:Fluent="clr-namespace:Fluent"
+                    xmlns:pr="clr-namespace:Fluent.Controls.Primitives"
                     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                     mc:Ignorable="d">
     <Style x:Key="RibbonTabItemStyle"
            TargetType="{x:Type Fluent:RibbonTabItem}">
         <Style.Triggers>
-            <Trigger Property="Group"
-                     Value="{x:Null}">
-                <Setter Property="BorderBrush"
-                        Value="{DynamicResource RibbonTopBorderBrush}" />
+            <Trigger Property="Group" Value="{x:Null}">
+                <Setter Property="BorderBrush" Value="{DynamicResource RibbonTopBorderBrush}" />
             </Trigger>
-            <Trigger Property="Selector.IsSelected"
-                     Value="False">
-                <Setter Property="Foreground"
-                        Value="{DynamicResource TabItemFontBrush}" />
+            <Trigger Property="Selector.IsSelected" Value="False">
+                <Setter Property="Foreground" Value="{DynamicResource TabItemFontBrush}" />
             </Trigger>
         </Style.Triggers>
-        <Setter Property="HorizontalAlignment"
-                Value="Left" />
-        <Setter Property="VerticalAlignment"
-                Value="Top" />
-        <Setter Property="Height"
-                Value="Auto" />
-        <Setter Property="IsMinimized"
-                Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Fluent:RibbonTabControl}}, Path=IsMinimized, Mode=OneWay, FallbackValue=False}" />
-        <Setter Property="IsOpen"
-                Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Fluent:RibbonTabControl}}, Path=IsDropDownOpen, Mode=OneWay, FallbackValue=True}" />
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="Indent" Value="12" />
+        <Setter Property="Foreground" Value="{DynamicResource TabItemSelectedFontBrush}" />
+        <Setter Property="BorderBrush" Value="{Binding Group.BorderBrush, RelativeSource={RelativeSource Self}}" />
+        <Setter Property="FocusVisualStyle" Value="{DynamicResource ControlStyleEmptyFocus}" />
+        <Setter Property="HorizontalAlignment" Value="Left" />
+        <Setter Property="IsMinimized" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Fluent:RibbonTabControl}}, Path=IsMinimized, Mode=OneWay, FallbackValue=False}" />
+        <Setter Property="IsOpen" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Fluent:RibbonTabControl}}, Path=IsDropDownOpen, Mode=OneWay, FallbackValue=True}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Fluent:RibbonTabItem}">
-                    <Grid x:Name="grid"
-                          Background="#00000000"
-                          Height="Auto"
-                          VerticalAlignment="Top"
-                          Margin="0,7,0,0">
+                    <Grid Margin="0,7,0,0">
+                        <pr:RibbonTabItemBorder x:Name="Border"
+                                                Background="Transparent"
+                                                BorderThickness="1"
+                                                BorderBrush="Transparent"
+                                                InnerBorderBrush="{DynamicResource ActiveTabBackgroundBrush}"
+                                                CornerRadius="2">
+                            <Border x:Name="PART_ContentContainer"
+                                    HorizontalAlignment="Stretch"
+                                    Margin="6,2,4,0"
+                                    VerticalAlignment="Stretch"
+                                    Padding="15,0,0,0"
+                                    Grid.ColumnSpan="1">
+                                <ContentPresenter x:Name="contentPresenter"
+                                                  AutomationProperties.Name="{TemplateBinding Header}"
+                                                  AutomationProperties.AutomationId="{TemplateBinding Name}"
+                                                  Content="{TemplateBinding Header}"
+                                                  Margin="0, -3, 0,0"
+                                                  HorizontalAlignment="Center"
+                                                  VerticalAlignment="Center"
+                                                  Height="Auto" />
+                            </Border>
+                        </pr:RibbonTabItemBorder>
+                        <Grid x:Name="separatorGrid"
+                              Visibility="Collapsed"
+                              HorizontalAlignment="Right"
+                              Margin="0,0,-1,0"
+                              Width="2">
+                            <Rectangle x:Name="separatorRectangle1"
+                                       Fill="{DynamicResource RibbonTopBorderBrush}"
+                                       Stroke="{DynamicResource RibbonTopBorderBrush}"
+                                       Margin="0,0,1,0"
+                                       HorizontalAlignment="Right"
+                                       Width="1"
+                                       Opacity="1"
+                                       Visibility="Visible">
+                                <Rectangle.OpacityMask>
+                                    <LinearGradientBrush EndPoint="0.5,1" StartPoint="0.5,0">
+                                        <GradientStop Color="#00000000" Offset="0" />
+                                        <GradientStop Color="#E5FFFFFF" Offset="0.382" />
+                                    </LinearGradientBrush>
+                                </Rectangle.OpacityMask>
+                            </Rectangle>
+                            <Rectangle x:Name="separatorRectangle2"
+                                       Fill="{DynamicResource ActiveTabBackgroundBrush}"
+                                       Stroke="{DynamicResource ActiveTabBackgroundBrush}"
+                                       HorizontalAlignment="Right"
+                                       Margin="0"
+                                       Width="1"
+                                       Opacity="1"
+                                       Visibility="Visible">
+                                <Rectangle.OpacityMask>
+                                    <LinearGradientBrush EndPoint="0.5,1" StartPoint="0.5,0">
+                                        <GradientStop Color="#00000000" Offset="0" />
+                                        <GradientStop Color="#BFFFFFFF" Offset="0.329" />
+                                    </LinearGradientBrush>
+                                </Rectangle.OpacityMask>
+                            </Rectangle>
+                        </Grid>
+
                         <Border x:Name="border3"
-                                Margin="2,0,0,1"
+                                Margin="1,0"
                                 BorderThickness="1,0"
                                 Grid.ColumnSpan="2">
                             <Border.BorderBrush>
@@ -53,12 +103,9 @@
                                     BorderBrush="{Binding Group.BorderBrush, RelativeSource={RelativeSource TemplatedParent}}"
                                     BorderThickness="1,0">
                                 <Border.OpacityMask>
-                                    <LinearGradientBrush EndPoint="0.5,1"
-                                                         StartPoint="0.5,0">
-                                        <GradientStop Color="Black"
-                                                      Offset="0" />
-                                        <GradientStop Color="#00000000"
-                                                      Offset="0.981" />
+                                    <LinearGradientBrush EndPoint="0.5,1" StartPoint="0.5,0">
+                                        <GradientStop Color="Black" Offset="0" />
+                                        <GradientStop Color="#00000000" Offset="0.981" />
                                     </LinearGradientBrush>
                                 </Border.OpacityMask>
                                 <Border Background="{Binding Group.Background, RelativeSource={RelativeSource TemplatedParent}}"
@@ -89,430 +136,86 @@
                                 </Border>
                             </Border>
                         </Border>
-                        <Grid x:Name="selectedGrid"
-                              Visibility="Collapsed"
-                              Margin="2,0,0,0"
-                              Grid.ColumnSpan="1">
-                            <Rectangle x:Name="rectangle"
-                                       Fill="{DynamicResource ActiveTabBackgroundBrush}"
-                                       Stroke="{x:Null}"
-                                       StrokeThickness="0"
-                                       Margin="0"
-                                       VerticalAlignment="Bottom"
-                                       Height="1" />
-                            <Rectangle x:Name="rectangle1"
-                                       Fill="{DynamicResource ActiveTabBackgroundBrush}"
-                                       Stroke="{x:Null}"
-                                       StrokeThickness="0"
-                                       Margin="1.8,0"
-                                       VerticalAlignment="Bottom"
-                                       Height="1.2" />
-                            <Rectangle x:Name="rectangle2"
-                                       Fill="{DynamicResource ActiveTabBackgroundBrush}"
-                                       Stroke="{x:Null}"
-                                       StrokeThickness="0"
-                                       Margin="2,0"
-                                       VerticalAlignment="Bottom"
-                                       Height="2" />
-                            <Border x:Name="border"
-                                    Margin="1,0,1,2"
-                                    BorderBrush="{TemplateBinding BorderBrush}"
-                                    BorderThickness="1,1,1,0"
-                                    VerticalAlignment="Stretch"
-                                    CornerRadius="2,2,0,0"
-                                    Background="{DynamicResource ActiveTabBackgroundBrush}">
-                                <Border x:Name="border_Copy3"
-                                        Margin="0"
-                                        BorderThickness="1,1,1,0"
-                                        VerticalAlignment="Stretch"
-                                        CornerRadius="2,2,0,0"
-                                        Background="{x:Null}"
-                                        BorderBrush="{DynamicResource ActiveTabBackgroundBrush}">
-                                    <Border x:Name="border_Copy4"
-                                            Margin="0,0,-2,-1"
-                                            BorderThickness="0"
-                                            VerticalAlignment="Stretch"
-                                            CornerRadius="2,2,0,0"
-                                            Background="{Binding Group.Background, RelativeSource={RelativeSource TemplatedParent}}"
-                                            BorderBrush="{x:Null}">
-                                        <Border.OpacityMask>
-                                            <LinearGradientBrush EndPoint="0.5,1"
-                                                                 StartPoint="0.5,0">
-                                                <GradientStop Color="#3F000000"
-                                                              Offset="0" />
-                                                <GradientStop Color="#00000000"
-                                                              Offset="0.59" />
-                                            </LinearGradientBrush>
-                                        </Border.OpacityMask>
-                                    </Border>
-                                </Border>
-                            </Border>
-                            <Border x:Name="border1"
-                                    HorizontalAlignment="Left"
-                                    Margin="0"
-                                    VerticalAlignment="Bottom"
-                                    Width="2"
-                                    Height="2"
-                                    BorderBrush="{TemplateBinding BorderBrush}"
-                                    BorderThickness="0,0,1,1"
-                                    CornerRadius="0,0,2,0" />
-                            <Border x:Name="border2"
-                                    HorizontalAlignment="Right"
-                                    Margin="0"
-                                    VerticalAlignment="Bottom"
-                                    Width="2"
-                                    Height="2"
-                                    BorderBrush="{TemplateBinding BorderBrush}"
-                                    BorderThickness="1,0,0,1"
-                                    CornerRadius="0,0,0,2" />
-                            <Rectangle x:Name="rectangle3"
-                                       StrokeThickness="0"
-                                       Margin="7,-7,7,0"
-                                       VerticalAlignment="Top"
-                                       Height="14"
-                                       IsHitTestVisible="False">
-                                <Rectangle.Fill>
-                                    <RadialGradientBrush Center="0.498,0.501"
-                                                         GradientOrigin="0.498,0.501"
-                                                         RadiusY="0.464">
-                                        <GradientStop Color="#7FFFFFFF"
-                                                      Offset="0" />
-                                        <GradientStop Offset="1" />
-                                    </RadialGradientBrush>
-                                </Rectangle.Fill>
-                            </Rectangle>
-                        </Grid>
-                        <Grid x:Name="hoverGrid"
-                              Margin="2,0,0,0"
-                              Visibility="Collapsed"
-                              Grid.ColumnSpan="1">
-                            <Border x:Name="border_Copy"
-                                    Margin="1,0,1,1"
-                                    BorderBrush="{TemplateBinding BorderBrush}"
-                                    BorderThickness="1,1,1,0"
-                                    VerticalAlignment="Stretch"
-                                    CornerRadius="2,2,0,0"
-                                    Background="{x:Null}">
-                                <Border.OpacityMask>
-                                    <LinearGradientBrush EndPoint="0.5,1"
-                                                         StartPoint="0.5,0">
-                                        <GradientStop Color="#CC000000"
-                                                      Offset="0" />
-                                        <GradientStop Color="#F7FFFFFF"
-                                                      Offset="0.985" />
-                                    </LinearGradientBrush>
-                                </Border.OpacityMask>
-                                <Border x:Name="border_Copy1"
-                                        Margin="0"
-                                        BorderBrush="{DynamicResource ActiveTabBackgroundBrush}"
-                                        BorderThickness="1,1,1,0"
-                                        VerticalAlignment="Stretch"
-                                        CornerRadius="2,2,0,0"
-                                        Background="{x:Null}">
-                                    <Border.OpacityMask>
-                                        <LinearGradientBrush EndPoint="0.5,1"
-                                                             StartPoint="0.5,0">
-                                            <GradientStop Color="#CCFFFFFF"
-                                                          Offset="0" />
-                                            <GradientStop Color="#F7FFFFFF"
-                                                          Offset="1" />
-                                        </LinearGradientBrush>
-                                    </Border.OpacityMask>
-                                    <Border x:Name="border_Copy2"
-                                            Margin="0"
-                                            BorderBrush="{x:Null}"
-                                            BorderThickness="0"
-                                            VerticalAlignment="Stretch"
-                                            CornerRadius="2,2,0,0"
-                                            Background="{DynamicResource ActiveTabBackgroundBrush}">
-                                        <Border.OpacityMask>
-                                            <LinearGradientBrush EndPoint="0.5,1"
-                                                                 StartPoint="0.5,0">
-                                                <GradientStop Color="#7FFFFFFF"
-                                                              Offset="0.004" />
-                                                <GradientStop Offset="0.5" />
-                                            </LinearGradientBrush>
-                                        </Border.OpacityMask>
-                                    </Border>
-                                </Border>
-                            </Border>
-                        </Grid>
-                        <Grid x:Name="focusedGrid"
-                              Margin="2,0,0,0"
-                              Visibility="Collapsed"
-                              Grid.ColumnSpan="1">
-                            <Grid.OpacityMask>
-                                <LinearGradientBrush EndPoint="0.5,1"
-                                                     StartPoint="0.5,0">
-                                    <GradientStop Color="White"
-                                                  Offset="0" />
-                                    <GradientStop Offset="1"
-                                                  Color="#19FFFFFF" />
-                                </LinearGradientBrush>
-                            </Grid.OpacityMask>
-                            <Border x:Name="border_Copy5"
-                                    Margin="1,0,1,1"
-                                    BorderThickness="1,1,1,0"
-                                    VerticalAlignment="Stretch"
-                                    CornerRadius="2,2,0,0"
-                                    Background="{DynamicResource ButtonHoverOuterBackgroundBrush}"
-                                    BorderBrush="{DynamicResource ButtonHoverOuterBorderBrush}">
-                                <Border x:Name="border_Copy6"
-                                        Margin="0"
-                                        BorderBrush="{DynamicResource ButtonHoverInnerBorderBrush}"
-                                        BorderThickness="1,1,1,0"
-                                        VerticalAlignment="Stretch"
-                                        CornerRadius="2,2,0,0"
-                                        Background="{DynamicResource ButtonHoverInnerBackgroundBrush}" />
-                            </Border>
-                        </Grid>
-                        <Border x:Name="PART_ContentContainer"
-                                HorizontalAlignment="Stretch"
-                                Margin="6,2,4,0"
-                                VerticalAlignment="Stretch"
-                                Padding="15,0,0,0"
-                                Grid.ColumnSpan="1">
-                            <!--<ContentPresenter x:Name="contentPresenter" ContentSource="Header" HorizontalAlignment="Center" VerticalAlignment="Center" Height="Auto"/>-->
-                            <Label x:Name="contentPresenter"
-                                   AutomationProperties.Name="{TemplateBinding Header}"
-                                   AutomationProperties.AutomationId="{TemplateBinding Name}"
-                                   Content="{TemplateBinding Header}"
-                                   Margin="0, -3, 0,0"
-                                   HorizontalAlignment="Center"
-                                   VerticalAlignment="Center"
-                                   Height="Auto" />
-                        </Border>
-                        <Grid x:Name="separatorGrid"
-                              Margin="0"
-                              Visibility="Collapsed"
-                              HorizontalAlignment="Right"
-                              Width="2"
-                              Grid.Column="1">
-                            <Rectangle x:Name="separatorRectangle1"
-                                       Fill="{DynamicResource RibbonTopBorderBrush}"
-                                       Stroke="{DynamicResource RibbonTopBorderBrush}"
-                                       Margin="0,0,1,0"
-                                       HorizontalAlignment="Right"
-                                       Width="1"
-                                       Opacity="1"
-                                       Visibility="Visible">
-                                <Rectangle.OpacityMask>
-                                    <LinearGradientBrush EndPoint="0.5,1"
-                                                         StartPoint="0.5,0">
-                                        <GradientStop Color="#00000000"
-                                                      Offset="0" />
-                                        <GradientStop Color="#E5FFFFFF"
-                                                      Offset="0.382" />
-                                    </LinearGradientBrush>
-                                </Rectangle.OpacityMask>
-                            </Rectangle>
-                            <Rectangle x:Name="separatorRectangle2"
-                                       Fill="{DynamicResource ActiveTabBackgroundBrush}"
-                                       Stroke="{DynamicResource ActiveTabBackgroundBrush}"
-                                       HorizontalAlignment="Right"
-                                       Margin="0"
-                                       Width="1"
-                                       Opacity="1"
-                                       Visibility="Visible">
-                                <Rectangle.OpacityMask>
-                                    <LinearGradientBrush EndPoint="0.5,1"
-                                                         StartPoint="0.5,0">
-                                        <GradientStop Color="#00000000"
-                                                      Offset="0" />
-                                        <GradientStop Color="#BFFFFFFF"
-                                                      Offset="0.329" />
-                                    </LinearGradientBrush>
-                                </Rectangle.OpacityMask>
-                            </Rectangle>
-                        </Grid>
                     </Grid>
+                    
                     <ControlTemplate.Triggers>
-                        <Trigger Property="IsEnabled"
-                                 Value="False">
-                            <Setter Property="Opacity"
-                                    TargetName="contentPresenter"
-                                    Value="0.5" />
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.5" />
                         </Trigger>
-                        <!--<Trigger Property="IsKeyboardFocused" Value="True">
-              <Setter Property="Visibility" TargetName="focusedGrid" Value="Visible"/>
-            </Trigger>-->
+
+
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
-                                <Condition Property="HasRightGroupBorder"
-                                           Value="False" />
-                                <Condition Property="HasLeftGroupBorder"
-                                           Value="True" />
+                                <Condition Property="HasRightGroupBorder" Value="False" />
+                                <Condition Property="HasLeftGroupBorder" Value="True" />
                             </MultiTrigger.Conditions>
-                            <Setter Property="BorderThickness"
-                                    TargetName="border3"
-                                    Value="1,0,0,0" />
-                            <Setter Property="BorderThickness"
-                                    TargetName="border4"
-                                    Value="1,0,0,0" />
-                            <Setter Property="Margin"
-                                    TargetName="rectangle4"
-                                    Value="0" />
+                            <Setter Property="BorderThickness" TargetName="border3" Value="1,0,0,0" />
+                            <Setter Property="BorderThickness" TargetName="border4" Value="1,0,0,0" />
+                            <Setter Property="Margin" TargetName="rectangle4" Value="0" />
+                            <Setter Property="Margin" TargetName="border3" Value="1,0,0,0" />
                         </MultiTrigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
-                                <Condition Property="HasLeftGroupBorder"
-                                           Value="False" />
-                                <Condition Property="HasRightGroupBorder"
-                                           Value="True" />
+                                <Condition Property="HasLeftGroupBorder" Value="False" />
+                                <Condition Property="HasRightGroupBorder" Value="True" />
                             </MultiTrigger.Conditions>
-                            <Setter Property="BorderThickness"
-                                    TargetName="border4"
-                                    Value="0,0,1,0" />
-                            <Setter Property="BorderThickness"
-                                    TargetName="border3"
-                                    Value="0,0,1,0" />
-                            <Setter Property="Margin"
-                                    TargetName="rectangle4"
-                                    Value="0" />
-                            <Setter Property="Margin"
-                                    TargetName="border3"
-                                    Value="0,0,0,1" />
+                            <Setter Property="BorderThickness" TargetName="border4" Value="0,0,1,0" />
+                            <Setter Property="BorderThickness" TargetName="border3" Value="0,0,1,0" />
+                            <Setter Property="Margin" TargetName="rectangle4" Value="0" />
+                            <Setter Property="Margin" TargetName="border3" Value="0,0,1,0" />
                         </MultiTrigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
-                                <Condition Property="HasLeftGroupBorder"
-                                           Value="False" />
-                                <Condition Property="HasRightGroupBorder"
-                                           Value="False" />
+                                <Condition Property="HasLeftGroupBorder" Value="False" />
+                                <Condition Property="HasRightGroupBorder" Value="False" />
                             </MultiTrigger.Conditions>
-                            <Setter Property="BorderThickness"
-                                    TargetName="border4"
-                                    Value="0,0,0,0" />
-                            <Setter Property="BorderThickness"
-                                    TargetName="border3"
-                                    Value="0,0,0,0" />
-                            <Setter Property="Margin"
-                                    TargetName="rectangle4"
-                                    Value="0" />
-                            <Setter Property="Margin"
-                                    TargetName="border3"
-                                    Value="0,0,0,1" />
+                            <Setter Property="BorderThickness" TargetName="border4" Value="0,0,0,0" />
+                            <Setter Property="BorderThickness" TargetName="border3" Value="0,0,0,0" />
+                            <Setter Property="Margin" TargetName="rectangle4" Value="0" />
+                            <Setter Property="Margin" TargetName="border3" Value="0" />
                         </MultiTrigger>
-                        <!--<MultiTrigger>
+
+
+                        <MultiTrigger>
                             <MultiTrigger.Conditions>
-                                <Condition Property="HasLeftGroupBorder"
-                                           Value="True" />
-                                <Condition Property="HasRightGroupBorder"
-                                           Value="True" />
+                                <Condition Property="IsMouseOver" Value="True" />
+                                <Condition Property="Selector.IsSelected" Value="False" />
+                                <Condition Property="IsMinimized" Value="False" />
                             </MultiTrigger.Conditions>
-                            <Setter Property="Margin"
-                                    TargetName="rectangle4"
-                                    Value="0" />
-                            <Setter Property="BorderThickness"
-                                    TargetName="border4"
-                                    Value="1,0,1,0" />
-                            <Setter Property="BorderThickness"
-                                    TargetName="border3"
-                                    Value="1,0,1,0" />
-                            <Setter Property="Margin"
-                                    TargetName="border3"
-                                    Value="1,0,0,1" />
-                        </MultiTrigger>-->
-                        <Trigger Property="Group"
-                                 Value="{x:Null}">
-                            <Setter Property="Visibility"
-                                    TargetName="border3"
-                                    Value="Collapsed" />
-                            <Setter Property="Margin"
-                                    TargetName="separatorGrid"
-                                    Value="-1,0,0,1" />
-                            <Setter Property="Visibility"
-                                    TargetName="border_Copy3"
-                                    Value="Collapsed" />
-                            <Setter Property="Visibility"
-                                    TargetName="rectangle3"
-                                    Value="Collapsed" />
+                            <Setter TargetName="Border"
+                                    Property="RenderInnerBorder"
+                                    Value="True" />
+                            <Setter TargetName="Border"
+                                    Property="BorderBrush"
+                                    Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderBrush}" />
+                        </MultiTrigger>
+                        <MultiTrigger>
+                            <MultiTrigger.Conditions>
+                                <Condition Property="Selector.IsSelected" Value="True" />
+                                <Condition Property="IsMinimized" Value="False" />
+                                <Condition Property="Fluent:RibbonTabControl.HighlightSelectedItem" Value="True" />
+                            </MultiTrigger.Conditions>
+                            <Setter TargetName="Border"
+                                    Property="Background"
+                                    Value="{DynamicResource ActiveTabBackgroundBrush}" />
+                            <Setter TargetName="Border"
+                                    Property="BorderBrush"
+                                    Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderBrush}" />
+                        </MultiTrigger>
+                        <Trigger Property="Group" Value="{x:Null}">
+                            <!--<Setter Property="Visibility" TargetName="border3" Value="Collapsed" />
+                            <Setter Property="Margin" TargetName="separatorGrid" Value="-1,0,0,1" />
+                            <Setter Property="Visibility" TargetName="border_Copy3" Value="Collapsed" />
+                            <Setter Property="Visibility" TargetName="rectangle3" Value="Collapsed" />-->
                         </Trigger>
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="Selector.IsSelected"
-                                           Value="True" />
-                                <Condition Property="IsMinimized"
-                                           Value="False" />
-                                <Condition Property="Fluent:RibbonTabControl.HighlightSelectedItem"
-                                           Value="True" />
-                            </MultiTrigger.Conditions>
-                            <Setter Property="Visibility"
-                                    TargetName="selectedGrid"
-                                    Value="Visible" />
-                        </MultiTrigger>
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="IsMouseOver"
-                                           Value="True" />
-                                <Condition Property="Selector.IsSelected"
-                                           Value="False" />
-                                <Condition Property="IsMinimized"
-                                           Value="False" />
-                            </MultiTrigger.Conditions>
-                            <Setter Property="Visibility"
-                                    TargetName="hoverGrid"
-                                    Value="Visible" />
-                        </MultiTrigger>
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="IsMouseOver"
-                                           Value="True" />
-                                <Condition Property="IsMinimized"
-                                           Value="True" />
-                                <Condition Property="IsOpen"
-                                           Value="False" />
-                            </MultiTrigger.Conditions>
-                            <Setter Property="Visibility"
-                                    TargetName="hoverGrid"
-                                    Value="Visible" />
-                        </MultiTrigger>
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="Selector.IsSelected"
-                                           Value="True" />
-                                <Condition Property="IsMinimized"
-                                           Value="True" />
-                                <Condition Property="IsOpen"
-                                           Value="True" />
-                            </MultiTrigger.Conditions>
-                            <Setter Property="Visibility"
-                                    TargetName="hoverGrid"
-                                    Value="Visible" />
-                            <Setter Property="Background"
-                                    TargetName="grid"
-                                    Value="#00000000" />
-                        </MultiTrigger>
-                        <Trigger Property="IsSeparatorVisible"
-                                 Value="True">
+                        <Trigger Property="IsSeparatorVisible" Value="True">
                             <Setter Property="Visibility"
                                     TargetName="separatorGrid"
                                     Value="Visible" />
-                            <Setter Property="Margin"
-                                    TargetName="PART_ContentContainer"
-                                    Value="6,2,6,0" />
-                            <Setter Property="Margin"
-                                    TargetName="hoverGrid"
-                                    Value="2,0" />
-                            <Setter Property="Margin"
-                                    TargetName="selectedGrid"
-                                    Value="2,0" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-        <Setter Property="IsTabStop"
-                Value="False" />
-        <Setter Property="Indent"
-                Value="12" />
-        <Setter Property="Foreground"
-                Value="{DynamicResource TabItemSelectedFontBrush}" />
-        <Setter Property="Margin"
-                Value="0" />
-        <Setter Property="BorderBrush"
-                Value="{Binding Group.BorderBrush, RelativeSource={RelativeSource Self}}" />
-        <Setter Property="FocusVisualStyle"
-                Value="{DynamicResource ControlStyleEmptyFocus}" />
     </Style>
 </ResourceDictionary>

--- a/Fluent/Themes/Office2010/Controls/RibbonTabItem.xaml
+++ b/Fluent/Themes/Office2010/Controls/RibbonTabItem.xaml
@@ -6,9 +6,12 @@
                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                     mc:Ignorable="d">
     
-    <Style x:Key="RibbonTabItemSeparatorStyle" TargetType="Separator">
-        <Setter Property="OverridesDefaultStyle" Value="True" />
-        <Setter Property="Width" Value="2" />
+    <Style x:Key="RibbonTabItemSeparatorStyle"
+           TargetType="Separator">
+        <Setter Property="OverridesDefaultStyle"
+                Value="True" />
+        <Setter Property="Width"
+                Value="2" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Separator">
@@ -22,9 +25,12 @@
                                        Opacity="1"
                                        Visibility="Visible">
                             <Rectangle.OpacityMask>
-                                <LinearGradientBrush EndPoint="0.5,1" StartPoint="0.5,0">
-                                    <GradientStop Color="#00000000" Offset="0" />
-                                    <GradientStop Color="#E5FFFFFF" Offset="0.382" />
+                                <LinearGradientBrush EndPoint="0.5,1"
+                                                     StartPoint="0.5,0">
+                                    <GradientStop Color="#00000000"
+                                                  Offset="0" />
+                                    <GradientStop Color="#E5FFFFFF"
+                                                  Offset="0.382" />
                                 </LinearGradientBrush>
                             </Rectangle.OpacityMask>
                         </Rectangle>
@@ -38,8 +44,10 @@
                                        Visibility="Visible">
                             <Rectangle.OpacityMask>
                                 <LinearGradientBrush EndPoint="0.5,1" StartPoint="0.5,0">
-                                    <GradientStop Color="#00000000" Offset="0" />
-                                    <GradientStop Color="#BFFFFFFF" Offset="0.329" />
+                                    <GradientStop Color="#00000000"
+                                                  Offset="0" />
+                                    <GradientStop Color="#BFFFFFFF"
+                                                  Offset="0.329" />
                                 </LinearGradientBrush>
                             </Rectangle.OpacityMask>
                         </Rectangle>
@@ -53,20 +61,30 @@
            TargetType="{x:Type Fluent:RibbonTabItem}">
         <Style.Triggers>
             <Trigger Property="Group" Value="{x:Null}">
-                <Setter Property="BorderBrush" Value="{DynamicResource RibbonTopBorderBrush}" />
+                <Setter Property="BorderBrush"
+                        Value="{DynamicResource RibbonTopBorderBrush}" />
             </Trigger>
             <Trigger Property="Selector.IsSelected" Value="False">
-                <Setter Property="Foreground" Value="{DynamicResource TabItemFontBrush}" />
+                <Setter Property="Foreground"
+                        Value="{DynamicResource TabItemFontBrush}" />
             </Trigger>
         </Style.Triggers>
-        <Setter Property="IsTabStop" Value="False" />
-        <Setter Property="Indent" Value="12" />
-        <Setter Property="Foreground" Value="{DynamicResource TabItemSelectedFontBrush}" />
-        <Setter Property="BorderBrush" Value="{Binding Group.BorderBrush, RelativeSource={RelativeSource Self}}" />
-        <Setter Property="FocusVisualStyle" Value="{DynamicResource ControlStyleEmptyFocus}" />
-        <Setter Property="HorizontalAlignment" Value="Left" />
-        <Setter Property="IsMinimized" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Fluent:RibbonTabControl}}, Path=IsMinimized, Mode=OneWay, FallbackValue=False}" />
-        <Setter Property="IsOpen" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Fluent:RibbonTabControl}}, Path=IsDropDownOpen, Mode=OneWay, FallbackValue=True}" />
+        <Setter Property="IsTabStop"
+                Value="False" />
+        <Setter Property="Indent"
+                Value="12" />
+        <Setter Property="Foreground"
+                Value="{DynamicResource TabItemSelectedFontBrush}" />
+        <Setter Property="BorderBrush"
+                Value="{Binding Group.BorderBrush, RelativeSource={RelativeSource Self}}" />
+        <Setter Property="FocusVisualStyle"
+                Value="{DynamicResource ControlStyleEmptyFocus}" />
+        <Setter Property="HorizontalAlignment"
+                Value="Left" />
+        <Setter Property="IsMinimized"
+                Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Fluent:Ribbon}}, Path=IsMinimized, Mode=OneWay, FallbackValue=False}" />
+        <Setter Property="IsOpen"
+                Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Fluent:Ribbon}}, Path=IsDropDownOpen, Mode=OneWay, FallbackValue=True}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Fluent:RibbonTabItem}">
@@ -115,9 +133,12 @@
                                     BorderBrush="{Binding Group.BorderBrush, RelativeSource={RelativeSource TemplatedParent}}"
                                     BorderThickness="1,0">
                                 <Border.OpacityMask>
-                                    <LinearGradientBrush EndPoint="0.5,1" StartPoint="0.5,0">
-                                        <GradientStop Color="Black" Offset="0" />
-                                        <GradientStop Color="#00000000" Offset="0.981" />
+                                    <LinearGradientBrush EndPoint="0.5,1"
+                                                         StartPoint="0.5,0">
+                                        <GradientStop Color="Black"
+                                                      Offset="0" />
+                                        <GradientStop Color="#00000000"
+                                                      Offset="0.981" />
                                     </LinearGradientBrush>
                                 </Border.OpacityMask>
                                 <Border Background="{Binding Group.Background, RelativeSource={RelativeSource TemplatedParent}}">
@@ -148,47 +169,82 @@
                     </pr:SingleCellGrid>
                     
                     <ControlTemplate.Triggers>
-                        <Trigger Property="IsEnabled" Value="False">
-                            <Setter Property="Opacity" Value="0.5" />
+                        <Trigger Property="IsEnabled"
+                                 Value="False">
+                            <Setter Property="Opacity"
+                                    Value="0.5" />
                         </Trigger>
                         
                         <!-- Contextual Tabs Triggers -->
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
-                                <Condition Property="HasRightGroupBorder" Value="False" />
-                                <Condition Property="HasLeftGroupBorder" Value="True" />
+                                <Condition Property="HasRightGroupBorder"
+                                           Value="False" />
+                                <Condition Property="HasLeftGroupBorder"
+                                           Value="True" />
                             </MultiTrigger.Conditions>
-                            <Setter Property="BorderThickness" TargetName="border3" Value="1,0,0,0" />
-                            <Setter Property="BorderThickness" TargetName="border4" Value="1,0,0,0" />
-                            <Setter Property="Margin" TargetName="rectangle4" Value="0" />
-                            <Setter Property="Margin" TargetName="border3" Value="1,0,0,1" />
+                            <Setter Property="BorderThickness"
+                                    TargetName="border3"
+                                    Value="1,0,0,0" />
+                            <Setter Property="BorderThickness"
+                                    TargetName="border4"
+                                    Value="1,0,0,0" />
+                            <Setter Property="Margin"
+                                    TargetName="rectangle4"
+                                    Value="0" />
+                            <Setter Property="Margin"
+                                    TargetName="border3"
+                                    Value="1,0,0,1" />
                         </MultiTrigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
-                                <Condition Property="HasLeftGroupBorder" Value="False" />
-                                <Condition Property="HasRightGroupBorder" Value="True" />
+                                <Condition Property="HasLeftGroupBorder"
+                                           Value="False" />
+                                <Condition Property="HasRightGroupBorder"
+                                           Value="True" />
                             </MultiTrigger.Conditions>
-                            <Setter Property="BorderThickness" TargetName="border4" Value="0,0,1,0" />
-                            <Setter Property="BorderThickness" TargetName="border3" Value="0,0,1,0" />
-                            <Setter Property="Margin" TargetName="rectangle4" Value="0" />
-                            <Setter Property="Margin" TargetName="border3" Value="0,0,1,1" />
+                            <Setter Property="BorderThickness"
+                                    TargetName="border4"
+                                    Value="0,0,1,0" />
+                            <Setter Property="BorderThickness"
+                                    TargetName="border3"
+                                    Value="0,0,1,0" />
+                            <Setter Property="Margin"
+                                    TargetName="rectangle4"
+                                    Value="0" />
+                            <Setter Property="Margin"
+                                    TargetName="border3"
+                                    Value="0,0,1,1" />
                         </MultiTrigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
-                                <Condition Property="HasLeftGroupBorder" Value="False" />
-                                <Condition Property="HasRightGroupBorder" Value="False" />
+                                <Condition Property="HasLeftGroupBorder"
+                                           Value="False" />
+                                <Condition Property="HasRightGroupBorder"
+                                           Value="False" />
                             </MultiTrigger.Conditions>
-                            <Setter Property="BorderThickness" TargetName="border4" Value="0,0,0,0" />
-                            <Setter Property="BorderThickness" TargetName="border3" Value="0,0,0,0" />
-                            <Setter Property="Margin" TargetName="rectangle4" Value="0" />
-                            <Setter Property="Margin" TargetName="border3" Value="0,0,0,1" />
+                            <Setter Property="BorderThickness"
+                                    TargetName="border4"
+                                    Value="0,0,0,0" />
+                            <Setter Property="BorderThickness"
+                                    TargetName="border3"
+                                    Value="0,0,0,0" />
+                            <Setter Property="Margin"
+                                    TargetName="rectangle4"
+                                    Value="0" />
+                            <Setter Property="Margin"
+                                    TargetName="border3"
+                                    Value="0,0,0,1" />
                         </MultiTrigger>
                         
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
-                                <Condition Property="IsMouseOver" Value="True" />
-                                <Condition Property="Selector.IsSelected" Value="False" />
-                                <Condition Property="IsMinimized" Value="False" />
+                                <Condition Property="IsMouseOver"
+                                           Value="True" />
+                                <Condition Property="Selector.IsSelected"
+                                           Value="False" />
+                                <Condition Property="IsMinimized"
+                                           Value="False" />
                             </MultiTrigger.Conditions>
                             <Setter TargetName="Border"
                                     Property="RenderInnerBorder"
@@ -199,9 +255,12 @@
                         </MultiTrigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
-                                <Condition Property="Selector.IsSelected" Value="True" />
-                                <Condition Property="IsMinimized" Value="False" />
-                                <Condition Property="Fluent:RibbonTabControl.HighlightSelectedItem" Value="True" />
+                                <Condition Property="Selector.IsSelected"
+                                           Value="True" />
+                                <Condition Property="IsMinimized"
+                                           Value="False" />
+                                <Condition Property="Fluent:RibbonTabControl.HighlightSelectedItem"
+                                           Value="True" />
                             </MultiTrigger.Conditions>
                             <Setter TargetName="Border"
                                     Property="Background"
@@ -211,17 +270,26 @@
                                     Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderBrush}" />
                         </MultiTrigger>
                         <Trigger Property="Group" Value="{x:Null}">
-                            <Setter Property="Visibility" TargetName="border3" Value="Collapsed" />
+                            <Setter Property="Visibility"
+                                    TargetName="border3"
+                                    Value="Collapsed" />
                         </Trigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
-                                <Condition Property="IsMouseOver" Value="True" />
-                                <Condition Property="IsMinimized" Value="True" />
+                                <Condition Property="IsMouseOver"
+                                           Value="True" />
+                                <Condition Property="IsMinimized"
+                                           Value="True" />
                             </MultiTrigger.Conditions>
-                            <Setter TargetName="Border" Property="RenderInnerBorder" Value="True" />
-                            <Setter TargetName="Border" Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderBrush}" />
+                            <Setter TargetName="Border"
+                                    Property="RenderInnerBorder"
+                                    Value="True" />
+                            <Setter TargetName="Border"
+                                    Property="BorderBrush"
+                                    Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderBrush}" />
                         </MultiTrigger>
-                        <Trigger Property="IsSeparatorVisible" Value="True">
+                        <Trigger Property="IsSeparatorVisible"
+                                 Value="True">
                             <Setter Property="Visibility"
                                     TargetName="separatorGrid"
                                     Value="Visible" />


### PR DESCRIPTION
This Pull Request is the result of what we discussed [here](https://github.com/fluentribbon/Fluent.Ribbon/issues/84), please review and let me know of any requires changes.

The goals of this Pull Request are:
* An easy to understand and customize template.
* A better performance, by reducing the visual tree complexity.

The goals are achieved by using:
* The **RibbonTabItemBorder** element will take care of creating and rendering the geometries of the selected and mouse over states, instead of combining a **Grid** and various elements to the achieve the same result.
* The **SingleCellGrid** panel is used to group related elements, instead of the **Grid** panel.