### PR TITLE
* repair nullref combobox combined with focus on winforms control

### DIFF
--- a/Fluent/Controls/ComboBox.cs
+++ b/Fluent/Controls/ComboBox.cs
@@ -647,7 +647,7 @@ namespace Fluent
             Mouse.Capture(this, CaptureMode.SubTree);
             if (SelectedItem != null) Keyboard.Focus(ItemContainerGenerator.ContainerFromItem(SelectedItem) as IInputElement);
             focusedElement = Keyboard.FocusedElement;
-            focusedElement.LostKeyboardFocus += OnFocusedElementLostKeyboardFocus;
+            if (focusedElement!=null) focusedElement.LostKeyboardFocus += OnFocusedElementLostKeyboardFocus;
 
             canSizeY = true;
 


### PR DESCRIPTION
Repro: When a winform control is hosted on wpf window and has focus (textbox), and combobox in ribbon opened.

This causes a null ref.