### PR TITLE
Fixed possible InvalidCastException when creating a QAT item

### DIFF
--- a/Fluent/Controls/CheckBox.cs
+++ b/Fluent/Controls/CheckBox.cs
@@ -108,7 +108,7 @@ namespace Fluent
         /// </summary>
         public object Icon
         {
-            get { return (ImageSource)GetValue(IconProperty); }
+            get { return GetValue(IconProperty); }
             set { SetValue(IconProperty, value); }
         }
 


### PR DESCRIPTION
Fixed a possible InvalidCastException when creating a QAT item from a checkbox with an Icon assigned as path.

If Icon is set to a "string" object (file path), using the getter will result in an Exception because it will try to cast to ImageSource unnecessarily.