### PR TITLE
Fixed #115 - IsSplited=True gray line issue in App Menu

### DIFF
--- a/Fluent/Themes/Office2010/Controls/ApplicationMenuItem.xaml
+++ b/Fluent/Themes/Office2010/Controls/ApplicationMenuItem.xaml
@@ -1571,7 +1571,7 @@
                                     <RowDefinition Height="*" />
                                     <RowDefinition Height="Auto" />
                                 </Grid.RowDefinitions>
-                                <Path Fill="{x:Null}"
+                                <!-- <Path Fill="{x:Null}"
                                       Stretch="Fill"
                                       Stroke="#FFE2E4E7"
                                       HorizontalAlignment="Left"
@@ -1580,7 +1580,7 @@
                                       Height="Auto"
                                       Data="M0,0L0,1"
                                       Grid.RowSpan="2"
-                                      Visibility="Visible" />
+                                      Visibility="Visible" /> -->
                                 <ScrollViewer Margin="1"
                                               x:Name="PART_ScrollViewer"
                                               Style="{DynamicResource MenuScrollViewer}"

--- a/Fluent/Themes/Windows8/Controls/ApplicationMenuItem.xaml
+++ b/Fluent/Themes/Windows8/Controls/ApplicationMenuItem.xaml
@@ -1523,7 +1523,7 @@
                                     <RowDefinition Height="*" />
                                     <RowDefinition Height="Auto" />
                                 </Grid.RowDefinitions>
-                                <Path Fill="{x:Null}"
+                                <!-- <Path Fill="{x:Null}"
                                       Stretch="Fill"
                                       Stroke="#FFE2E4E7"
                                       HorizontalAlignment="Left"
@@ -1532,7 +1532,7 @@
                                       Height="Auto"
                                       Data="M0,0L0,1"
                                       Grid.RowSpan="2"
-                                      Visibility="Visible" />
+                                      Visibility="Visible" /> -->
                                 <ScrollViewer Margin="1"
                                               x:Name="PART_ScrollViewer"
                                               Style="{DynamicResource MenuScrollViewer}"


### PR DESCRIPTION
Fix for #115
Commented same box for WIndows 8 (did not managed to do that changes
were shown only commented box, not all code..) and Office 2010 templates
- to not show Gray line.
<!-- <Path Fill="{x:Null}"
Stretch="Fill"
Stroke="#FFE2E4E7"
HorizontalAlignment="Left"
Margin="24,0,0,0"
Width="1"
Height="Auto"
Data="M0,0L0,1"
Grid.RowSpan="2"
Visibility="Visible" /> -->