### PR TITLE
Update ObjectToImageConverter.cs and RibbonTabItem.cs

### DIFF
--- a/Fluent/Controls/RibbonTabItem.cs
+++ b/Fluent/Controls/RibbonTabItem.cs
@@ -246,9 +246,7 @@ namespace Fluent
 
             if (e.NewValue != null)
             {
-                var tabGroup = (RibbonContextualTabGroup)e.NewValue;
-                tab.Visibility = tabGroup.Visibility;
-                tabGroup.AppendTabItem(tab);
+                ((RibbonContextualTabGroup)e.NewValue).AppendTabItem(tab);
                 tab.IsContextual = true;
             }
             else

--- a/Fluent/Controls/RibbonTabItem.cs
+++ b/Fluent/Controls/RibbonTabItem.cs
@@ -246,7 +246,9 @@ namespace Fluent
 
             if (e.NewValue != null)
             {
-                ((RibbonContextualTabGroup)e.NewValue).AppendTabItem(tab);
+                var tabGroup = (RibbonContextualTabGroup)e.NewValue;
+                tab.Visibility = tabGroup.Visibility;
+                tabGroup.AppendTabItem(tab);
                 tab.IsContextual = true;
             }
             else

--- a/Fluent/Converters/ObjectToImageConverter.cs
+++ b/Fluent/Converters/ObjectToImageConverter.cs
@@ -47,6 +47,12 @@
                 return CreateImage(imagePath, desiredSize);
             }
 
+            var imageUri = value as Uri;
+            if (imageUri != null)
+            {
+                return CreateImage(imageUri, desiredSize);
+            }
+
             var imageSource = value as ImageSource;
 
             if (imageSource == null)
@@ -88,15 +94,39 @@
             }
 
             return new Image
+            {
+                Source = new BitmapImage(new Uri(imagePath, UriKind.RelativeOrAbsolute), new RequestCachePolicy(RequestCacheLevel.NoCacheNoStore))
+            };
+        }
+        private static Image CreateImage(Uri imageUri, double desiredSize)
+        {
+            if (double.IsNaN(desiredSize) == false
+                && imageUri.AbsolutePath.EndsWith(".ico"))
+            {
+                return new Image
                 {
-                    Source = new BitmapImage(new Uri(imagePath, UriKind.RelativeOrAbsolute), new RequestCachePolicy(RequestCacheLevel.NoCacheNoStore))
+                    Source = ExtractImageFromIcoFile(imageUri, desiredSize)
                 };
+            }
+
+            return new Image
+            {
+                Source = new BitmapImage(imageUri, new RequestCachePolicy(RequestCacheLevel.NoCacheNoStore))
+            };
         }
 
         private static ImageSource ExtractImageFromIcoFile(string imagePath, double desiredSize)
         {
-            var decoder = BitmapDecoder.Create(
+            return ExtractImageFromIcoFile(
                 new Uri("pack://application:,,," + imagePath, UriKind.RelativeOrAbsolute),
+                desiredSize
+                );
+        }
+
+        private static ImageSource ExtractImageFromIcoFile(Uri imageUri, double desiredSize)
+        {
+            var decoder = BitmapDecoder.Create(
+                imageUri,
                 BitmapCreateOptions.DelayCreation | BitmapCreateOptions.IgnoreImageCache,
                 BitmapCacheOption.None
                 );


### PR DESCRIPTION
- ObjectToImageConveter accepts an Uri object
- Synchronizes the visibility of RibbonContextualTabGroup and RibbonTabItem when adding RibbonTabItem to RibbonContextualTabGroup