### PR TITLE
Implemented CanMinimize property 

### DIFF
--- a/Fluent/Controls/Ribbon.cs
+++ b/Fluent/Controls/Ribbon.cs
@@ -1518,6 +1518,7 @@ namespace Fluent
                 this.TabControl.SelectionChanged += this.OnTabControlSelectionChanged;
 
                 this.TabControl.IsMinimized = this.IsMinimized;
+                this.TabControl.CanMinimize = this.CanMinimize;
                 this.TabControl.ContentGapHeight = this.ContentGapHeight;
 
                 this.TabControl.SetBinding(RibbonTabControl.IsMinimizedProperty, new Binding("IsMinimized") { Source = this, Mode = BindingMode.TwoWay });

--- a/Fluent/Controls/Ribbon.cs
+++ b/Fluent/Controls/Ribbon.cs
@@ -981,6 +981,14 @@ namespace Fluent
             DependencyProperty.Register("CanCustomizeRibbon", typeof(bool),
             typeof(Ribbon), new UIPropertyMetadata(false));
 
+        /// <summary>
+        /// Gets or sets whether ribbon can be minimized
+        /// </summary>
+        public bool CanMinimize
+        {
+            get { return (bool)this.GetValue(CanMinimizeProperty); }
+            set { this.SetValue(CanMinimizeProperty, value); }
+        }
 
         /// <summary>
         /// Gets or sets whether ribbon is minimized
@@ -998,6 +1006,13 @@ namespace Fluent
         public static readonly DependencyProperty IsMinimizedProperty =
             DependencyProperty.Register("IsMinimized", typeof(bool),
             typeof(Ribbon), new UIPropertyMetadata(false, OnIsMinimizedChanged));
+
+        /// <summary>
+        /// Using a DependencyProperty as the backing store for CanMinimize.  This enables animation, styling, binding, etc...
+        /// </summary>
+        public static readonly DependencyProperty CanMinimizeProperty =
+            DependencyProperty.Register("CanMinimize", typeof(bool), typeof(Ribbon), new UIPropertyMetadata(true));
+
 
         private static void OnIsMinimizedChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {

--- a/Fluent/Controls/Ribbon.cs
+++ b/Fluent/Controls/Ribbon.cs
@@ -287,6 +287,16 @@ namespace Fluent
             // Set minimize the ribbon menu item state
             minimizeTheRibbonMenuItem.IsChecked = ribbon.IsMinimized;
 
+            // Set minimize the ribbon menu item visibility
+            if (ribbon.CanMinimize)
+            {
+                minimizeTheRibbonMenuItem.Visibility = Visibility.Visible;
+            }
+            else
+            {
+                minimizeTheRibbonMenuItem.Visibility = Visibility.Collapsed;
+            }
+
             // Set customize the ribbon menu item visibility
             if (ribbon.CanCustomizeRibbon)
             {
@@ -1175,7 +1185,7 @@ namespace Fluent
             if (ribbon != null
                 && ribbon.TabControl != null)
             {
-                e.CanExecute = true;
+                e.CanExecute = ribbon.CanMinimize;
             }
         }
 

--- a/Fluent/Controls/Ribbon.cs
+++ b/Fluent/Controls/Ribbon.cs
@@ -1021,7 +1021,7 @@ namespace Fluent
         /// Using a DependencyProperty as the backing store for CanMinimize.  This enables animation, styling, binding, etc...
         /// </summary>
         public static readonly DependencyProperty CanMinimizeProperty =
-            DependencyProperty.Register("CanMinimize", typeof(bool), typeof(Ribbon), new UIPropertyMetadata(true));
+            DependencyProperty.Register("CanMinimize", typeof(bool), typeof(Ribbon), new UIPropertyMetadata(true, OnCanMinimizeChanged));
 
 
         private static void OnIsMinimizedChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -1032,6 +1032,13 @@ namespace Fluent
             {
                 ribbon.IsMinimizedChanged(ribbon, e);
             }
+        }
+
+        private static void OnCanMinimizeChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var ribbon = (Ribbon)d;
+
+            ribbon.TabControl.CanMinimize = ribbon.CanMinimize;
         }
 
         /// <summary>
@@ -1517,8 +1524,8 @@ namespace Fluent
             {
                 this.TabControl.SelectionChanged += this.OnTabControlSelectionChanged;
 
-                this.TabControl.IsMinimized = this.IsMinimized;
                 this.TabControl.CanMinimize = this.CanMinimize;
+                this.TabControl.IsMinimized = this.IsMinimized;
                 this.TabControl.ContentGapHeight = this.ContentGapHeight;
 
                 this.TabControl.SetBinding(RibbonTabControl.IsMinimizedProperty, new Binding("IsMinimized") { Source = this, Mode = BindingMode.TwoWay });
@@ -1778,7 +1785,10 @@ namespace Fluent
             {
                 if (this.TabControl.HasItems)
                 {
-                    this.IsMinimized = !this.IsMinimized;
+                    if(this.CanMinimize)
+                    {
+                        this.IsMinimized = !this.IsMinimized;
+                    }
                 }
             }
         }

--- a/Fluent/Controls/RibbonTabControl.cs
+++ b/Fluent/Controls/RibbonTabControl.cs
@@ -123,12 +123,18 @@ namespace Fluent
         /// </summary>
         public static readonly DependencyProperty IsMinimizedProperty = DependencyProperty.Register("IsMinimized", typeof(bool), typeof(RibbonTabControl), new UIPropertyMetadata(false, OnMinimizedChanged));
 
+        /// <summary>
+        /// Gets or sets whether ribbon can be minimized
+        /// </summary>
         public bool CanMinimize
         {
             get { return (bool)this.GetValue(CanMinimizeProperty); }
             set { this.SetValue(CanMinimizeProperty, value); }
         }
 
+        /// <summary>
+        /// Using a DependencyProperty as the backing store for <see cref="CanMinimize"/>.  This enables animation, styling, binding, etc...
+        /// </summary>
         public static readonly DependencyProperty CanMinimizeProperty = DependencyProperty.Register("CanMinimize", typeof(bool), typeof(RibbonTabControl), new UIPropertyMetadata(true, OnCanMinimizeChanged));
 
 

--- a/Fluent/Controls/RibbonTabControl.cs
+++ b/Fluent/Controls/RibbonTabControl.cs
@@ -124,6 +124,21 @@ namespace Fluent
         public static readonly DependencyProperty IsMinimizedProperty = DependencyProperty.Register("IsMinimized", typeof(bool), typeof(RibbonTabControl), new UIPropertyMetadata(false, OnMinimizedChanged));
 
         /// <summary>
+        /// Gets or sets whether ribbon can be minimized
+        /// </summary>
+        public bool CanMinimize
+        {
+            get { return (bool)this.GetValue(CanMinimizeProperty); }
+            set { this.SetValue(CanMinimizeProperty, value); }
+        }
+
+        /// <summary>
+        /// Using a DependencyProperty as the backing store for <see cref="CanMinimize"/>.  This enables animation, styling, binding, etc...
+        /// </summary>
+        public static readonly DependencyProperty CanMinimizeProperty = DependencyProperty.Register("CanMinimize", typeof(bool), typeof(RibbonTabControl), new UIPropertyMetadata(false));
+
+
+        /// <summary>
         /// Gets or sets whether ribbon popup is opened
         /// </summary>
         public bool IsDropDownOpen
@@ -668,6 +683,11 @@ namespace Fluent
         private static void OnMinimizedChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var tab = (RibbonTabControl)d;
+
+            if(tab.CanMinimize == false)
+            {
+                return;
+            }
 
             if (!tab.IsMinimized)
             {

--- a/Fluent/Controls/RibbonTabControl.cs
+++ b/Fluent/Controls/RibbonTabControl.cs
@@ -123,19 +123,13 @@ namespace Fluent
         /// </summary>
         public static readonly DependencyProperty IsMinimizedProperty = DependencyProperty.Register("IsMinimized", typeof(bool), typeof(RibbonTabControl), new UIPropertyMetadata(false, OnMinimizedChanged));
 
-        /// <summary>
-        /// Gets or sets whether ribbon can be minimized
-        /// </summary>
         public bool CanMinimize
         {
             get { return (bool)this.GetValue(CanMinimizeProperty); }
             set { this.SetValue(CanMinimizeProperty, value); }
         }
 
-        /// <summary>
-        /// Using a DependencyProperty as the backing store for <see cref="CanMinimize"/>.  This enables animation, styling, binding, etc...
-        /// </summary>
-        public static readonly DependencyProperty CanMinimizeProperty = DependencyProperty.Register("CanMinimize", typeof(bool), typeof(RibbonTabControl), new UIPropertyMetadata(false));
+        public static readonly DependencyProperty CanMinimizeProperty = DependencyProperty.Register("CanMinimize", typeof(bool), typeof(RibbonTabControl), new UIPropertyMetadata(true, OnCanMinimizeChanged));
 
 
         /// <summary>
@@ -679,15 +673,29 @@ namespace Fluent
             }
         }
 
+        // Handles CanMinimizeChanges
+        private static void OnCanMinimizeChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var tab = (RibbonTabControl)d;
+            var toggleButton = tab.Template.FindName("PART_MinimizeButton", tab) as Fluent.ToggleButton;
+            if (toggleButton != null)
+            {
+                if (tab.CanMinimize)
+                {
+
+                    toggleButton.Visibility = Visibility.Visible;
+                }
+                else
+                {
+                    toggleButton.Visibility = Visibility.Collapsed;
+                }
+            }
+        }
+
         // Handles IsMinimized changed
         private static void OnMinimizedChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var tab = (RibbonTabControl)d;
-
-            if(tab.CanMinimize == false)
-            {
-                return;
-            }
 
             if (!tab.IsMinimized)
             {

--- a/Fluent/Controls/RibbonTabItem.cs
+++ b/Fluent/Controls/RibbonTabItem.cs
@@ -609,7 +609,11 @@ namespace Fluent
 
                 if (this.TabControlParent != null)
                 {
-                    this.TabControlParent.IsMinimized = !this.TabControlParent.IsMinimized;
+                    var canMinimize = this.FindParentRibbon().CanMinimize;
+                    if (canMinimize)
+                    {
+                        this.TabControlParent.IsMinimized = !this.TabControlParent.IsMinimized;
+                    }
                 }
             }
             else if (e.Source == this

--- a/Fluent/Controls/RibbonTabItem.cs
+++ b/Fluent/Controls/RibbonTabItem.cs
@@ -609,7 +609,7 @@ namespace Fluent
 
                 if (this.TabControlParent != null)
                 {
-                    var canMinimize = this.FindParentRibbon().CanMinimize;
+                    var canMinimize = this.TabControlParent.CanMinimize;
                     if (canMinimize)
                     {
                         this.TabControlParent.IsMinimized = !this.TabControlParent.IsMinimized;

--- a/FluentTest/TestContent.xaml
+++ b/FluentTest/TestContent.xaml
@@ -441,6 +441,9 @@
                     <Fluent:CheckBox IsChecked="{Binding IsMinimized, RelativeSource={RelativeSource AncestorType={x:Type Fluent:Ribbon}}}">
                         IsMinimized
                     </Fluent:CheckBox>
+                    <Fluent:CheckBox IsChecked="{Binding CanMinimize, RelativeSource={RelativeSource AncestorType={x:Type Fluent:Ribbon}}}">
+                        CanMinimize
+                    </Fluent:CheckBox>
                     <Fluent:CheckBox IsChecked="{Binding IsCollapsed, RelativeSource={RelativeSource AncestorType={x:Type Fluent:Ribbon}}}">
                         IsCollapsed
                     </Fluent:CheckBox>


### PR DESCRIPTION
PR for #230 

The change to the ContextMenu was pretty easy and did just require some changes in the Ribbon. To disable the "DoubleClick"-Close behaviour I needed to change the RibbonItemControl. 
The little "Close" icon was challenging... I did it just via code. Maybe this could also be done inside the styles, but I wasn't sure if you prefer this way.

It's working, but if you set CanMinimize to false and set IsMinimize to true it might be a strange behavior.

What do you think?