### PR TITLE
Basic fix for KeyTips not working when focus is inside a WinForms control

### DIFF
--- a/Fluent.Ribbon.Showcase/Fluent.Ribbon.Showcase.NET 4.5.csproj
+++ b/Fluent.Ribbon.Showcase/Fluent.Ribbon.Showcase.NET 4.5.csproj
@@ -54,6 +54,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core">
     </Reference>
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\MahApps.Metro.1.1.2.0\lib\net45\System.Windows.Interactivity.dll</HintPath>
       <Private>True</Private>
@@ -68,6 +69,7 @@
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
+    <Reference Include="WindowsFormsIntegration" />
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">

--- a/Fluent.Ribbon.Showcase/TestContent.xaml
+++ b/Fluent.Ribbon.Showcase/TestContent.xaml
@@ -8,6 +8,7 @@
              xmlns:Helpers="clr-namespace:FluentTest.Helpers"
              xmlns:System="clr-namespace:System;assembly=mscorlib"
              xmlns:viewModels="clr-namespace:FluentTest.ViewModels"
+             xmlns:forms="clr-namespace:System.Windows.Forms;assembly=System.Windows.Forms"
              mc:Ignorable="d"
              d:DesignHeight="600"
              d:DesignWidth="800"
@@ -2592,6 +2593,12 @@
                         <LineBreak />
                         It is bundled with Office 2010, Office 2013 and Windows 8 themes.
                     </TextBlock>
+
+                    <WindowsFormsHost>
+                        <forms:TextBox Height="30" Text="Test WinFormsHost" />
+                    </WindowsFormsHost>
+
+                    <TextBox>Test WPF TextBox</TextBox>
                 </StackPanel>
             </TabItem>
             <TabItem Header="Developer">

--- a/Fluent.Ribbon/Adorners/KeyTipAdorner.cs
+++ b/Fluent.Ribbon/Adorners/KeyTipAdorner.cs
@@ -265,7 +265,7 @@ namespace Fluent
 
             // Clears previous user input
             this.enteredKeys = "";
-            this.FilterKeyTips();
+            this.FilterKeyTips(this.enteredKeys);
 
             // Show this adorner
             this.adornerLayer.Add(this);
@@ -440,7 +440,7 @@ namespace Fluent
                 return;
             }
 
-            if ((!(this.AdornedElement is ContextMenu)) &&
+            if ((!(this.AdornedElement is ContextMenu) && (!(this.AdornedElement is MenuItem))) &&
                 ((e.Key == Key.Left) || (e.Key == Key.Right) || (e.Key == Key.Up) || (e.Key == Key.Down) ||
                 (e.Key == Key.Enter) || (e.Key == Key.Tab)))
             {
@@ -469,7 +469,7 @@ namespace Fluent
                 }
                 else
                 {
-                    this.FilterKeyTips();
+                    this.FilterKeyTips(this.enteredKeys);
                 }
 
                 e.Handled = true;
@@ -682,7 +682,7 @@ namespace Fluent
         /// </summary>
         /// <param name="keys"></param>
         /// <returns></returns>
-        private bool IsElementsStartWith(string keys)
+        public bool IsElementsStartWith(string keys)
         {
             foreach (var keyTip in this.keyTips.Where(x => x.IsEnabled))
             {
@@ -698,7 +698,7 @@ namespace Fluent
         }
 
         // Hide / unhide keytips relative matching to entered keys
-        private void FilterKeyTips()
+        internal void FilterKeyTips(string currentlyEnteredKeys)
         {
             this.Log("FilterKeyTips");
 
@@ -713,13 +713,13 @@ namespace Fluent
             {
                 var content = (string)this.keyTips[i].Content;
 
-                if (string.IsNullOrEmpty(this.enteredKeys))
+                if (string.IsNullOrEmpty(currentlyEnteredKeys))
                 {
                     this.keyTips[i].Visibility = this.backupedVisibilities[i];
                 }
                 else
                 {
-                    this.keyTips[i].Visibility = content.StartsWith(this.enteredKeys, StringComparison.CurrentCultureIgnoreCase)
+                    this.keyTips[i].Visibility = content.StartsWith(currentlyEnteredKeys, StringComparison.CurrentCultureIgnoreCase)
                         ? this.backupedVisibilities[i]
                         : Visibility.Collapsed;
                 }


### PR DESCRIPTION
When pressing Alt and then a letter (input focus: WinForms textbox), Alt
will make the KeyTips show, but the letter will be typed into the
focused WinForms control instead of navigating through the ribbon. As
far as I can see, the reason for this is primarily that
OnFocusedElementPreviewTextInput can not be attached to the currently
focused WinForms control. This behaviour has not been an issue in older
versions of Fluent.

In order to fix the problem, in OnWindowKeyDown() e.Key will be
forwarded to the KeyTip adorners. This fix is incomplete though. Since
all keys must be set to "handled" here to avoid typing into the WinForms
textbox, this will also swallow the "up/down" navigation in menus. I'm
not quite sure what the best approach for fixing this should be.

I also modified the showcase app to show the two different textboxes for
testing the key tip behaviours in both scenarios.