### PR TITLE
Menu navigation working for the post part

### DIFF
--- a/Fluent.Ribbon/Controls/MenuItem.cs
+++ b/Fluent.Ribbon/Controls/MenuItem.cs
@@ -653,6 +653,15 @@ namespace Fluent
         }
 
         /// <summary>
+        /// Allows KeyTipService to control menu items.
+        /// </summary>
+        /// <param name="e"></param>
+        internal void HandleKeyDown(KeyEventArgs e)
+        {
+            this.OnKeyDown(e);
+        }
+
+        /// <summary>
         /// Responds to the <see cref="E:System.Windows.UIElement.KeyDown"/> event. 
         /// </summary>
         /// <param name="e">The event data for the <see cref="E:System.Windows.UIElement.KeyDown"/> event.</param>

--- a/Fluent.Ribbon/Services/KeyTipService.cs
+++ b/Fluent.Ribbon/Services/KeyTipService.cs
@@ -238,12 +238,18 @@ namespace Fluent
                     return;
                 }
 
-                // Should we show the keytips and immediately react to key?
-                if (this.activeAdornerChain == null
-                    || this.activeAdornerChain.IsAdornerChainAlive == false
-                    || this.activeAdornerChain.AreAnyKeyTipsVisible == false)
+                Key actualKey = e.Key == Key.System ? e.SystemKey : e.Key;
+                bool isLetterKey = ((actualKey >= Key.A && actualKey <= Key.Z) || (actualKey >= Key.D0 && actualKey <= Key.D9) || (actualKey >= Key.NumPad0 && actualKey <= Key.NumPad9));
+
+                if (isLetterKey)
                 {
-                    this.ShowImmediatly();
+                    // Should we show the keytips and immediately react to key?
+                    if (this.activeAdornerChain == null
+                        || this.activeAdornerChain.IsAdornerChainAlive == false
+                        || this.activeAdornerChain.AreAnyKeyTipsVisible == false)
+                    {
+                        this.ShowImmediatly();
+                    }
                 }
 
                 if (this.activeAdornerChain == null)
@@ -253,11 +259,21 @@ namespace Fluent
 
                 string previousInput = this.currentUserInput;
 
-                this.currentUserInput += keyConverter.ConvertToString(e.Key == Key.System ? e.SystemKey : e.Key);
+                if (isLetterKey)
+                {
+                    this.currentUserInput += keyConverter.ConvertToString(actualKey);
+                }
 
                 // If no key tips match the current input, continue with the previously entered and still correct keys.
-                if (this.activeAdornerChain.ActiveKeyTipAdorner.ContainsKeyTipStartingWith(this.currentUserInput) == false)
+                if (!isLetterKey || this.activeAdornerChain.ActiveKeyTipAdorner.ContainsKeyTipStartingWith(this.currentUserInput) == false)
                 {
+                    MenuItem item = Keyboard.FocusedElement as MenuItem;
+                    if (item != null && !isLetterKey)
+                    {
+                        item.HandleKeyDown(e);
+                        return;
+                    }
+
                     this.currentUserInput = previousInput;
                     System.Media.SystemSounds.Beep.Play();
                 }


### PR DESCRIPTION
Still not working: Focus WinForms Textbox, navigate into submenu and use
"Left" key to go back to the previous menu.

The System.Windows.Controls.MenuItem apparently doesn't want to handle the "Left" key but it's not really evident why that would be the case.