### PR TITLE
Show underscore of header text on RibbonTabItem

### DIFF
--- a/Fluent/Themes/Office2010/Controls/RibbonTabItem.xaml
+++ b/Fluent/Themes/Office2010/Controls/RibbonTabItem.xaml
@@ -273,7 +273,7 @@
                                 Padding="15,0,0,0"
                                 Grid.ColumnSpan="1">
                             <!--<ContentPresenter x:Name="contentPresenter" ContentSource="Header" HorizontalAlignment="Center" VerticalAlignment="Center" Height="Auto"/>-->
-                            <Label x:Name="contentPresenter"
+                            <ContentControl x:Name="contentPresenter"
                                    AutomationProperties.Name="{TemplateBinding Header}"
                                    AutomationProperties.AutomationId="{TemplateBinding Name}"
                                    Content="{TemplateBinding Header}"

--- a/Fluent/Themes/Office2010/Controls/RibbonTabItem.xaml
+++ b/Fluent/Themes/Office2010/Controls/RibbonTabItem.xaml
@@ -277,7 +277,7 @@
                                    AutomationProperties.Name="{TemplateBinding Header}"
                                    AutomationProperties.AutomationId="{TemplateBinding Name}"
                                    Content="{TemplateBinding Header}"
-                                   Margin="0, -3, 0,0"
+                                   Margin="5,2,5,5"
                                    HorizontalAlignment="Center"
                                    VerticalAlignment="Center"
                                    Height="Auto" />

--- a/Fluent/Themes/Office2013/Controls/RibbonTabItem.xaml
+++ b/Fluent/Themes/Office2013/Controls/RibbonTabItem.xaml
@@ -125,7 +125,7 @@
                     Padding="15,0,0,0"
                     Grid.ColumnSpan="1">
                 <!--<ContentPresenter x:Name="contentPresenter" ContentSource="Header" HorizontalAlignment="Center" VerticalAlignment="Center" Height="Auto"/>-->
-                <Label x:Name="contentPresenter"
+                <ContentControl x:Name="contentPresenter"
                        AutomationProperties.Name="{TemplateBinding Header}"
                        AutomationProperties.AutomationId="{TemplateBinding Name}"
                        Content="{TemplateBinding Header}"

--- a/Fluent/Themes/Office2013/Controls/RibbonTabItem.xaml
+++ b/Fluent/Themes/Office2013/Controls/RibbonTabItem.xaml
@@ -129,7 +129,7 @@
                        AutomationProperties.Name="{TemplateBinding Header}"
                        AutomationProperties.AutomationId="{TemplateBinding Name}"
                        Content="{TemplateBinding Header}"
-                       Margin="0, -4, 0,-1"
+                       Margin="5,1,5,4"
                        HorizontalAlignment="Center"
                        VerticalAlignment="Center"
                        Height="Auto" />

--- a/Fluent/Themes/Windows8/Controls/RibbonTabItem.xaml
+++ b/Fluent/Themes/Windows8/Controls/RibbonTabItem.xaml
@@ -228,7 +228,7 @@
                                    AutomationProperties.Name="{TemplateBinding Header}"
                                    AutomationProperties.AutomationId="{TemplateBinding Name}"
                                    Content="{TemplateBinding Header}"
-                                   Margin="0, -3, 0,0"
+                                   Margin="5,2,5,5"
                                    HorizontalAlignment="Center"
                                    VerticalAlignment="Center"
                                    Height="Auto" />

--- a/Fluent/Themes/Windows8/Controls/RibbonTabItem.xaml
+++ b/Fluent/Themes/Windows8/Controls/RibbonTabItem.xaml
@@ -224,7 +224,7 @@
                                 Padding="15,0,0,0"
                                 Grid.ColumnSpan="1">
                             <!--<ContentPresenter x:Name="contentPresenter" ContentSource="Header" HorizontalAlignment="Center" VerticalAlignment="Center" Height="Auto"/>-->
-                            <Label x:Name="contentPresenter"
+                            <ContentControl x:Name="contentPresenter"
                                    AutomationProperties.Name="{TemplateBinding Header}"
                                    AutomationProperties.AutomationId="{TemplateBinding Name}"
                                    Content="{TemplateBinding Header}"


### PR DESCRIPTION
for issue #269 
I changed type of control from Label to ContentControl.
Because "Target" property of Label control is not used.