### PR TITLE
Fix for NullRef CanMinimize

### DIFF
--- a/Fluent.Ribbon/Controls/Ribbon.cs
+++ b/Fluent.Ribbon/Controls/Ribbon.cs
@@ -1051,8 +1051,10 @@ namespace Fluent
         private static void OnCanMinimizeChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             var ribbon = (Ribbon)d;
-
-            ribbon.TabControl.CanMinimize = ribbon.CanMinimize;
+            if (ribbon.TabControl != null)
+            {
+                ribbon.TabControl.CanMinimize = ribbon.CanMinimize;
+            }
         }
 
         /// <summary>

--- a/Fluent.Ribbon/Controls/RibbonTabControl.cs
+++ b/Fluent.Ribbon/Controls/RibbonTabControl.cs
@@ -126,7 +126,7 @@
         /// <summary>
         /// Using a DependencyProperty as the backing store for <see cref="CanMinimize"/>.  This enables animation, styling, binding, etc...
         /// </summary>
-        public static readonly DependencyProperty CanMinimizeProperty = DependencyProperty.Register("CanMinimize", typeof(bool), typeof(RibbonTabControl), new UIPropertyMetadata(true, OnCanMinimizeChanged));
+        public static readonly DependencyProperty CanMinimizeProperty = DependencyProperty.Register("CanMinimize", typeof(bool), typeof(RibbonTabControl), new UIPropertyMetadata(true));
 
 
         /// <summary>
@@ -667,25 +667,6 @@
             if (this.ItemContainerGenerator.Status == GeneratorStatus.ContainersGenerated)
             {
                 this.UpdateSelectedContent();
-            }
-        }
-
-        // Handles CanMinimizeChanges
-        private static void OnCanMinimizeChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        {
-            var tab = (RibbonTabControl)d;
-            var toggleButton = tab.Template.FindName("PART_MinimizeButton", tab) as Fluent.ToggleButton;
-            if (toggleButton != null)
-            {
-                if (tab.CanMinimize)
-                {
-
-                    toggleButton.Visibility = Visibility.Visible;
-                }
-                else
-                {
-                    toggleButton.Visibility = Visibility.Collapsed;
-                }
             }
         }
 

--- a/Fluent.Ribbon/Themes/Office2010/Controls/RibbonTabControl.xaml
+++ b/Fluent.Ribbon/Themes/Office2010/Controls/RibbonTabControl.xaml
@@ -497,7 +497,7 @@
                                                          Size="Small"
                                                          Style="{DynamicResource RibbonTabControlToggleButtonStyle}"
                                                          IsChecked="{Binding Path=IsMinimized, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
-                                                         Visibility="{TemplateBinding HasItems, Converter={StaticResource boolToVisibilityConverter}}" />
+                                                         Visibility="{TemplateBinding CanMinimize, Converter={StaticResource boolToVisibilityConverter}}" />
                                 </Grid>
                                 <StackPanel x:Name="PART_ToolbarPanel"
                                             Orientation="Horizontal" />

--- a/Fluent.Ribbon/Themes/Office2013/Controls/RibbonTabControl.xaml
+++ b/Fluent.Ribbon/Themes/Office2013/Controls/RibbonTabControl.xaml
@@ -340,7 +340,7 @@
                                              Size="Small"
                                              Style="{DynamicResource RibbonTabControlToggleButtonStyle}"
                                              IsChecked="{Binding Path=IsMinimized, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
-                                             Visibility="{TemplateBinding HasItems, Converter={StaticResource boolToVisibilityConverter}}" />
+                                             Visibility="{TemplateBinding CanMinimize, Converter={StaticResource boolToVisibilityConverter}}" />
                     </Grid>
 
                     <StackPanel x:Name="PART_ToolbarPanel"

--- a/Fluent.Ribbon/Themes/Windows8/Controls/RibbonTabControl.xaml
+++ b/Fluent.Ribbon/Themes/Windows8/Controls/RibbonTabControl.xaml
@@ -344,7 +344,7 @@
                                              Size="Small"
                                              Style="{DynamicResource RibbonTabControlToggleButtonStyle}"
                                              IsChecked="{Binding Path=IsMinimized, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
-                                             Visibility="{TemplateBinding HasItems, Converter={StaticResource boolToVisibilityConverter}}" />
+                                             Visibility="{TemplateBinding CanMinimize, Converter={StaticResource boolToVisibilityConverter}}" />
                     </Grid>
                     <StackPanel x:Name="PART_ToolbarPanel"
                                 Orientation="Horizontal" />


### PR DESCRIPTION
Null check for CanMinimize in Ribbon Control and moved the rendering part from code to XAML.

Should fix https://github.com/fluentribbon/Fluent.Ribbon/issues/268