### PR TITLE
Button Icon resizing

### DIFF
--- a/Fluent.Ribbon/Controls/Button.cs
+++ b/Fluent.Ribbon/Controls/Button.cs
@@ -115,6 +115,44 @@ namespace Fluent
         }
         #endregion
 
+        #region IconHeight
+
+        /// <summary>
+        /// Gets or sets icon height
+        /// </summary>
+        public int IconHeight
+        {
+            get { return (int)this.GetValue(IconHeightProperty); }
+            set { this.SetValue(IconHeightProperty, value); }
+        }
+
+        /// <summary>
+        /// Using a DependencyProperty as the backing store for IconHeight.  This enables animation, styling, binding, etc...
+        /// </summary>
+        public static readonly DependencyProperty IconHeightProperty =
+            DependencyProperty.Register("IconHeight", typeof(int), typeof(Button), new UIPropertyMetadata(32));
+
+        #endregion
+
+        #region IconWidth
+
+        /// <summary>
+        /// Gets or sets icon width
+        /// </summary>
+        public int IconWidth
+        {
+            get { return (int)this.GetValue(IconWidthProperty); }
+            set { this.SetValue(IconWidthProperty, value); }
+        }
+
+        /// <summary>
+        /// Using a DependencyProperty as the backing store for IconWidth.  This enables animation, styling, binding, etc...
+        /// </summary>
+        public static readonly DependencyProperty IconWidthProperty =
+            DependencyProperty.Register("IconWidth", typeof(int), typeof(Button), new UIPropertyMetadata(32));
+
+        #endregion
+
         #region LargeIcon
 
         /// <summary>

--- a/Fluent.Ribbon/Themes/Office2010/Controls/Button.xaml
+++ b/Fluent.Ribbon/Themes/Office2010/Controls/Button.xaml
@@ -42,10 +42,10 @@
                                 d:LayoutOverrides="Width, Height">
                         <ContentPresenter x:Name="iconImage"
                                           HorizontalAlignment="Center"
-                                          Height="32"
+                                          Height="{Binding IconHeight, RelativeSource={RelativeSource TemplatedParent}}"
                                           VerticalAlignment="Center"
                                           Content="{Binding LargeIcon, RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static Converters:StaticConverters.ObjectToImageConverter}}"
-                                          Width="32"
+                                          Width="{Binding IconWidth, RelativeSource={RelativeSource TemplatedParent}}"
                                           Margin="3,2,3,1"
                                           SnapsToDevicePixels="True" />
                         <Fluent:TwoLineLabel x:Name="controlLabel"

--- a/Fluent.Ribbon/Themes/Office2013/Controls/Button.xaml
+++ b/Fluent.Ribbon/Themes/Office2013/Controls/Button.xaml
@@ -22,10 +22,10 @@
                         d:LayoutOverrides="Width, Height">
                 <ContentPresenter x:Name="iconImage"
                                   HorizontalAlignment="Center"
-                                  Height="32"
+                                  Height="{Binding IconHeight, RelativeSource={RelativeSource TemplatedParent}}"
                                   VerticalAlignment="Center"
                                   Content="{Binding LargeIcon, RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static Converters:StaticConverters.ObjectToImageConverter}}"
-                                  Width="32"
+                                  Width="{Binding IconWidth, RelativeSource={RelativeSource TemplatedParent}}"
                                   Margin="3,2,3,1"
                                   SnapsToDevicePixels="True" />
                 <Fluent:TwoLineLabel x:Name="controlLabel"

--- a/Fluent.Ribbon/Themes/Windows8/Controls/Button.xaml
+++ b/Fluent.Ribbon/Themes/Windows8/Controls/Button.xaml
@@ -22,10 +22,10 @@
                         d:LayoutOverrides="Width, Height">
                 <ContentPresenter x:Name="iconImage"
                                   HorizontalAlignment="Center"
-                                  Height="32"
+                                  Height="{Binding IconHeight, RelativeSource={RelativeSource TemplatedParent}}"
                                   VerticalAlignment="Center"
                                   Content="{Binding LargeIcon, RelativeSource={RelativeSource TemplatedParent}, Converter={x:Static Converters:StaticConverters.ObjectToImageConverter}}"
-                                  Width="32"
+                                  Width="{Binding IconWidth, RelativeSource={RelativeSource TemplatedParent}}"
                                   Margin="3,2,3,1"
                                   SnapsToDevicePixels="True" />
                 <Fluent:TwoLineLabel x:Name="controlLabel"


### PR DESCRIPTION
My first attempt to add a new property;
Added IconHeight and IconWidth parameter, with default value 32, to Fluent:Button to allow resizing of the icon.

Two warnings before pulling:

1. I'm not sure as to why adding the IconHeight / IconWidth parameter to the Fluent:Button line results in a 'value not valid for parameter' warning. Instead, it adds the new parameters as ints seperately, like the following example. I'm guessing it has to do with the typecast to int, which I assume is required for the value to be correctly used?
```
<Fluent:Button Name="btnStuff" Header="Stuff" Icon="Images\Icon1.png" LargeIcon="Images\Icon1.png">
	<Fluent:Button.IconWidth>
		<System:Int32>32</System:Int32>
	</Fluent:Button.IconWidth>
	<Fluent:Button.IconHeight>
		<System:Int32>32</System:Int32>
	</Fluent:Button.IconHeight>
</Fluent:Button>
```
Any pointers on how this behaviour can be changed?

2. Setting the Button size (Large / Medium / Small) doesn't change the IconHeight / IconWidth value. I'm not sure where to fix this.

Any pointers are welcome.