### PR TITLE
Fix text going under custom window commands

### DIFF
--- a/Fluent.Ribbon/Themes/RibbonWindow.xaml
+++ b/Fluent.Ribbon/Themes/RibbonWindow.xaml
@@ -13,7 +13,13 @@
         <Grid>
             <AdornerDecorator x:Name="Adorner">
                 <Grid Background="{TemplateBinding Background}">
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="*" />
+						<ColumnDefinition Width="Auto" />
+					</Grid.ColumnDefinitions>
+
                     <DockPanel x:Name="PART_TitleBar"
+							   Grid.Column="0"
                                Height="{Binding Path=(Fluent:RibbonProperties.TitleBarHeight), RelativeSource={RelativeSource Self}}"
                                VerticalAlignment="Top"
                                HorizontalAlignment="Left"
@@ -29,13 +35,13 @@
 
                     <ContentPresenter Content="{Binding WindowCommands, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Fluent:RibbonWindow}}}"
                                       x:Name="PART_WindowCommands"
+									  Grid.Column="1"
                                       Panel.ZIndex="1"
-                                      Grid.RowSpan="2"
                                       VerticalAlignment="Top"
                                       HorizontalAlignment="Right"
                                       Height="{Binding Path=(Fluent:RibbonProperties.TitleBarHeight), RelativeSource={RelativeSource Self}}" />
 
-                    <ContentPresenter x:Name="PART_ContentPresenter" />
+                    <ContentPresenter x:Name="PART_ContentPresenter" Grid.ColumnSpan="2" />
                 </Grid>
             </AdornerDecorator>
 


### PR DESCRIPTION
I use something like the following in my app:

	<fluent:RibbonWindow.WindowCommands>
		<fluent:WindowCommands x:Name="WindowCommandsTitle">
			<StackPanel x:Name="StackPanelWindowCommands" Orientation="Horizontal" Margin="0 0 10 0" Visibility="{Binding Visibility}">
				<Button x:Name="buttonTitlebarSettings" Command="{Binding SettingsCommand}" Visibility="{Binding SettingsVisibility}"
						Style="{DynamicResource Styles.Button.WindowChrome}" ToolTip="{lex:Loc Options}">
					<Image Source="{DynamicResource Icons.Gray.Settings}" Style="{DynamicResource Styles.Images.Button.WindowChrome}" />
				</Button>
				<Button x:Name="buttonTitlebarInfo" Command="{Binding InfoCommand}" Visibility="{Binding InfoVisibility}"
						Style="{DynamicResource Styles.Button.WindowChrome}" ToolTip="{lex:Loc About}">
					<Image Source="{DynamicResource Icons.Gray.Info}" Style="{DynamicResource Styles.Images.Button.WindowChrome}" />
				</Button>
				<Button x:Name="buttonTitlebarHelp" Command="{Binding HelpCommand}" Visibility="{Binding HelpVisibility}"
						Style="{DynamicResource Styles.Button.WindowChrome}" ToolTip="{lex:Loc Help}">
					<Image Source="{DynamicResource Icons.Gray.Question}" Style="{DynamicResource Styles.Images.Button.WindowChrome}" />
				</Button>
			</StackPanel>
		</fluent:WindowCommands>
	</fluent:RibbonWindow.WindowCommands>

This in combination with a very long file name added to the window title causes this:
![image](https://cloud.githubusercontent.com/assets/1186179/17929913/ebfc3dde-6a03-11e6-9bbd-95344d345f33.png)

I think the reason is the "overlapping controls". I now moved the window commands to its own column to avoid this.