### PR TITLE
Fixed dependency property name of property Groups in GalleryGroupFilter.

### DIFF
--- a/Fluent.Ribbon/Controls/GalleryGroupFilter.cs
+++ b/Fluent.Ribbon/Controls/GalleryGroupFilter.cs
@@ -34,11 +34,11 @@ namespace Fluent
         }
 
         /// <summary>
-        /// Using a DependencyProperty as the backing store for ContextualGroups.  
+        /// Using a DependencyProperty as the backing store for Groups.  
         /// This enables animation, styling, binding, etc...
         /// </summary>
         public static readonly DependencyProperty GroupsProperty =
-            DependencyProperty.Register("ContextualGroups", typeof(string), 
+            DependencyProperty.Register("Groups", typeof(string), 
             typeof(GalleryGroupFilter), new UIPropertyMetadata(string.Empty));
     }
 }


### PR DESCRIPTION
The dependency property name was different than the actual property name, causing xaml parse exception when trying to bind on the Groups property.