### PR TITLE
Fix Ribbon.OnTitleBarChanged clearing the new title bar instead of the old one

### DIFF
--- a/Fluent.Ribbon.Tests/Controls/RibbonTests.cs
+++ b/Fluent.Ribbon.Tests/Controls/RibbonTests.cs
@@ -162,9 +162,8 @@
             {
                 ribbon.ApplyTemplate();
                 Assert.IsNotNull(ribbon.QuickAccessToolBar);
-                Assert.IsNotNull(ribbon.TitleBar);
 
-                var oldTitleBar = ribbon.TitleBar;
+                var oldTitleBar = ribbon.TitleBar = new RibbonTitleBar();
                 Assert.AreEqual(1, oldTitleBar.Items.Count);
                 Assert.AreSame(ribbon.QuickAccessToolBar, oldTitleBar.QuickAccessToolBar);
 

--- a/Fluent.Ribbon.Tests/Controls/RibbonTests.cs
+++ b/Fluent.Ribbon.Tests/Controls/RibbonTests.cs
@@ -153,5 +153,39 @@
                 Assert.That(element.Key.GetValue(property), Is.EqualTo(expectedValue), $"{property.Name} on {element.Value} should match.");
             }            
         }
+
+        [Test]
+        public void TitleBar_properties_synchronised_with_ribbon()
+        {
+            var ribbon = new Ribbon { ContextualGroups = { new RibbonContextualTabGroup() } };
+            using (new TestRibbonWindow(ribbon))
+            {
+                ribbon.ApplyTemplate();
+                Assert.IsNotNull(ribbon.QuickAccessToolBar);
+                Assert.IsNotNull(ribbon.TitleBar);
+
+                var oldTitleBar = ribbon.TitleBar;
+                Assert.AreEqual(1, oldTitleBar.Items.Count);
+                Assert.AreSame(ribbon.QuickAccessToolBar, oldTitleBar.QuickAccessToolBar);
+
+                var newTitleBar = new RibbonTitleBar();
+                Assert.AreEqual(0, newTitleBar.Items.Count);
+                Assert.IsNull(newTitleBar.QuickAccessToolBar);
+
+                // assign a new title bar, the contextual groups and quick access are transferred across
+                ribbon.TitleBar = newTitleBar;
+                Assert.AreEqual(0, oldTitleBar.Items.Count);
+                Assert.IsNull(oldTitleBar.QuickAccessToolBar);
+                Assert.AreEqual(1, newTitleBar.Items.Count);
+                Assert.AreSame(ribbon.QuickAccessToolBar, newTitleBar.QuickAccessToolBar);
+
+                // remove the title bar
+                ribbon.TitleBar = null;
+                Assert.AreEqual(0, oldTitleBar.Items.Count);
+                Assert.IsNull(oldTitleBar.QuickAccessToolBar);
+                Assert.AreEqual(0, newTitleBar.Items.Count);
+                Assert.IsNull(newTitleBar.QuickAccessToolBar);
+            }
+        }
     }
 }

--- a/Fluent.Ribbon/Controls/Ribbon.cs
+++ b/Fluent.Ribbon/Controls/Ribbon.cs
@@ -655,25 +655,25 @@ namespace Fluent
             {
                 foreach (var ribbonContextualTabGroup in ribbon.ContextualGroups)
                 {
-                    ribbon.TitleBar.Items.Remove(ribbonContextualTabGroup);
+                    oldValue.Items.Remove(ribbonContextualTabGroup);
                 }
 
                 // Make sure everything is cleared
-                ribbon.TitleBar.Items.Clear();
+                oldValue.Items.Clear();
 
-                ribbon.RemoveQuickAccessToolBarFromTitleBar();
+                ribbon.RemoveQuickAccessToolBarFromTitleBar(oldValue);
             }
 
             if (newValue != null)
             {
                 foreach (var contextualTabGroup in ribbon.ContextualGroups)
                 {
-                    ribbon.TitleBar.Items.Add(contextualTabGroup);
+                    newValue.Items.Add(contextualTabGroup);
                 }
 
                 if (ribbon.ShowQuickAccessToolBarAboveRibbon)
                 {
-                    ribbon.MoveQuickAccessToolBarToTitleBar();
+                    ribbon.MoveQuickAccessToolBarToTitleBar(newValue);
                 }
             }
         }
@@ -708,11 +708,11 @@ namespace Fluent
             {
                 if ((bool)e.NewValue)
                 {
-                    ribbon.MoveQuickAccessToolBarToTitleBar();
+                    ribbon.MoveQuickAccessToolBarToTitleBar(ribbon.TitleBar);
                 }
                 else
                 {
-                    ribbon.RemoveQuickAccessToolBarFromTitleBar();
+                    ribbon.RemoveQuickAccessToolBarFromTitleBar(ribbon.TitleBar);
                 }
 
                 ribbon.TitleBar.InvalidateMeasure();
@@ -1614,15 +1614,15 @@ namespace Fluent
 
             if (this.ShowQuickAccessToolBarAboveRibbon)
             {
-                this.MoveQuickAccessToolBarToTitleBar();
+                this.MoveQuickAccessToolBarToTitleBar(this.TitleBar);
             }
         }
 
-        private void MoveQuickAccessToolBarToTitleBar()
+        private void MoveQuickAccessToolBarToTitleBar(RibbonTitleBar titleBar)
         {
-            if (this.TitleBar != null)
+            if (titleBar != null)
             {
-                this.TitleBar.QuickAccessToolBar = this.QuickAccessToolBar;
+                titleBar.QuickAccessToolBar = this.QuickAccessToolBar;
             }
 
             if (this.QuickAccessToolBar != null)
@@ -1636,11 +1636,11 @@ namespace Fluent
             }
         }
 
-        private void RemoveQuickAccessToolBarFromTitleBar()
+        private void RemoveQuickAccessToolBarFromTitleBar(RibbonTitleBar titleBar)
         {
-            if (this.TitleBar != null)
+            if (titleBar != null)
             {
-                this.TitleBar.QuickAccessToolBar = null;
+                titleBar.QuickAccessToolBar = null;
             }
 
             if (this.QuickAccessToolBar != null)


### PR DESCRIPTION
Fixed **Ribbon.OnTitleBarChanged** not using the 'old value' when clearing the title bar properties (a null reference exception was being thrown when the new value is null).

For this to work the **RemoveQuickAccessToolBarFromTitleBar** and **MoveQuickAccessToolBarToTitleBar** methods now have a parameter to specify the **RibbonTitleBar** instance to act on.