### PR TITLE
Fix invisible RibbonTabControl background

### DIFF
--- a/Fluent.Ribbon/Themes/Colors/BaseDark.xaml
+++ b/Fluent.Ribbon/Themes/Colors/BaseDark.xaml
@@ -101,7 +101,7 @@
     <SolidColorBrush x:Key="Fluent.Ribbon.Brushes.RibbonGroupBox.Header.Foreground" Color="{StaticResource Gray2}" options:Freeze="True" />
     
     <!-- RibbonTabControl -->
-    <SolidColorBrush x:Key="Fluent.Ribbon.Brushes.RibbonTabControl.Background" Color="Transparent" options:Freeze="True" />
+    <SolidColorBrush x:Key="Fluent.Ribbon.Brushes.RibbonTabControl.Background" Color="{StaticResource WhiteColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="Fluent.Ribbon.Brushes.RibbonTabControl.Foreground" Color="{StaticResource BlackColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="Fluent.Ribbon.Brushes.RibbonTabControl.Content.Background" Color="Transparent" options:Freeze="True" />
     <SolidColorBrush x:Key="Fluent.Ribbon.Brushes.RibbonTabControl.Content.Foreground" Color="{StaticResource BlackColor}" options:Freeze="True" />

--- a/Fluent.Ribbon/Themes/Colors/BaseLight.xaml
+++ b/Fluent.Ribbon/Themes/Colors/BaseLight.xaml
@@ -101,7 +101,7 @@
     <SolidColorBrush x:Key="Fluent.Ribbon.Brushes.RibbonGroupBox.Header.Foreground" Color="{StaticResource Gray2}" options:Freeze="True" />
     
     <!-- RibbonTabControl -->
-    <SolidColorBrush x:Key="Fluent.Ribbon.Brushes.RibbonTabControl.Background" Color="Transparent" options:Freeze="True" />
+    <SolidColorBrush x:Key="Fluent.Ribbon.Brushes.RibbonTabControl.Background" Color="{StaticResource WhiteColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="Fluent.Ribbon.Brushes.RibbonTabControl.Foreground" Color="{StaticResource BlackColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="Fluent.Ribbon.Brushes.RibbonTabControl.Content.Background" Color="Transparent" options:Freeze="True" />
     <SolidColorBrush x:Key="Fluent.Ribbon.Brushes.RibbonTabControl.Content.Foreground" Color="{StaticResource BlackColor}" options:Freeze="True" />

--- a/Fluent.Ribbon/Themes/Colors/Colors.xaml
+++ b/Fluent.Ribbon/Themes/Colors/Colors.xaml
@@ -147,7 +147,7 @@
     <SolidColorBrush x:Key="Fluent.Ribbon.Brushes.RibbonGroupBox.Header.Foreground" Color="{StaticResource Gray2}" options:Freeze="True" />
     
     <!-- RibbonTabControl -->
-    <SolidColorBrush x:Key="Fluent.Ribbon.Brushes.RibbonTabControl.Background" Color="Transparent" options:Freeze="True" />
+    <SolidColorBrush x:Key="Fluent.Ribbon.Brushes.RibbonTabControl.Background" Color="{StaticResource WhiteColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="Fluent.Ribbon.Brushes.RibbonTabControl.Foreground" Color="{StaticResource BlackColor}" options:Freeze="True" />
     <SolidColorBrush x:Key="Fluent.Ribbon.Brushes.RibbonTabControl.Content.Background" Color="Transparent" options:Freeze="True" />
     <SolidColorBrush x:Key="Fluent.Ribbon.Brushes.RibbonTabControl.Content.Foreground" Color="{StaticResource BlackColor}" options:Freeze="True" />

--- a/Fluent.Ribbon/Themes/Controls/Ribbon.xaml
+++ b/Fluent.Ribbon/Themes/Controls/Ribbon.xaml
@@ -29,7 +29,7 @@
                 <Fluent:RibbonTabControl x:Name="PART_RibbonTabControl"
                                          Menu="{TemplateBinding Menu}"                                      
                                          ContentHeight="{TemplateBinding ContentHeight}"
-                                         ContextMenu="{Binding ContextMenu, ElementName=PART_LayoutRoot}"/>
+                                         ContextMenu="{Binding ContextMenu, ElementName=PART_LayoutRoot}" />
                 
                 <ContentControl x:Name="quickAccessToolBarHolder"
                             Grid.Row="1"

--- a/Fluent.Ribbon/Themes/Controls/Ribbon.xaml
+++ b/Fluent.Ribbon/Themes/Controls/Ribbon.xaml
@@ -29,7 +29,8 @@
                 <Fluent:RibbonTabControl x:Name="PART_RibbonTabControl"
                                          Menu="{TemplateBinding Menu}"                                      
                                          ContentHeight="{TemplateBinding ContentHeight}"
-                                         ContextMenu="{Binding ContextMenu, ElementName=PART_LayoutRoot}" />
+                                         ContextMenu="{Binding ContextMenu, ElementName=PART_LayoutRoot}" 
+                                         Background="{DynamicResource Fluent.Ribbon.Brushes.RibbonTabControl.Background}"/>
                 
                 <ContentControl x:Name="quickAccessToolBarHolder"
                             Grid.Row="1"

--- a/Fluent.Ribbon/Themes/Controls/Ribbon.xaml
+++ b/Fluent.Ribbon/Themes/Controls/Ribbon.xaml
@@ -29,8 +29,7 @@
                 <Fluent:RibbonTabControl x:Name="PART_RibbonTabControl"
                                          Menu="{TemplateBinding Menu}"                                      
                                          ContentHeight="{TemplateBinding ContentHeight}"
-                                         ContextMenu="{Binding ContextMenu, ElementName=PART_LayoutRoot}" 
-                                         Background="{DynamicResource Fluent.Ribbon.Brushes.RibbonTabControl.Background}"/>
+                                         ContextMenu="{Binding ContextMenu, ElementName=PART_LayoutRoot}"/>
                 
                 <ContentControl x:Name="quickAccessToolBarHolder"
                             Grid.Row="1"


### PR DESCRIPTION
Because of https://github.com/dady8889/Fluent.Ribbon/commit/219267c77e03fe3a1b0bfdc05f27f7f084b14967#diff-dd657b8658ea160ea5c919c0d9c80eeeL28, when you hide the ribbon and open individual tab item, their background is transparent.
