### PR TITLE
"Auto" size for ribbon group box header to support custom font sizes

### DIFF
--- a/Fluent.Ribbon/Themes/Controls/RibbonGroupBox.xaml
+++ b/Fluent.Ribbon/Themes/Controls/RibbonGroupBox.xaml
@@ -276,7 +276,7 @@
                           Height="Auto">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="*" />
-                            <RowDefinition Height="17" />
+                            <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
 
                         <Fluent:RibbonGroupBoxWrapPanel x:Name="PART_UpPanel"
@@ -286,13 +286,13 @@
                                                         Height="Auto"
                                                         IsItemsHost="True"
                                                         Margin="4,0,4,0" />
-                        
+
                         <Grid x:Name="PART_DownGrid"
                               MaxWidth="{Binding ActualWidth, ElementName=PART_ParentPanel}"
                               Margin="0,-2,2,2"
                               Grid.Row="1"
                               VerticalAlignment="Bottom"
-                              Height="17">
+                              Height="Auto">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="Auto" />
@@ -377,7 +377,7 @@
                         </Grid>
                     </Popup>
                 </Grid>
-                
+
                 <Rectangle x:Name="separator"
                            Fill="{DynamicResource Fluent.Ribbon.Brushes.GroupSeparator.Background}"
                            HorizontalAlignment="Right"
@@ -388,7 +388,7 @@
                            Margin="0,4"
                            Visibility="{Binding IsSeparatorVisible, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource BooleanToVisibilityConverter}}" />
             </Grid>
-            
+
             <Image x:Name="PART_SnappedImage"
                    Visibility="Collapsed" />
         </Grid>


### PR DESCRIPTION
We are currently implementing themes in our app and I found out that the group box name in the ribbon has a hard-coded height of 17, which is a problem if you increase the overall font-size or change to a larger font.
Changing that to "Auto" did not cause any problems as far as I could see, but makes it possible to increase the font-size without the need to overwrite the control-template on our side (which is what we do at the moment). This makes the following possible - a little crazy just to show of ;-):
![image](https://user-images.githubusercontent.com/1186179/38021096-3e4b41b0-327c-11e8-87bc-35a6a5b51a29.png)
==>
![image](https://user-images.githubusercontent.com/1186179/38021120-4dd2b104-327c-11e8-92b0-9671c58f96d5.png)

All other sizes could be adapted with inherited styles and just setting sizes to "Auto" or values calculated out of the font-size (like `ContentHeight` of the ribbon). If someone else wants to support this please send me a message and I'll collect all places I needed to adapt.