### PR TITLE
ignore Alt Gr key in KeyTips detection

### DIFF
--- a/Fluent.Ribbon/Services/KeyTipService.cs
+++ b/Fluent.Ribbon/Services/KeyTipService.cs
@@ -345,7 +345,24 @@ namespace Fluent
                 return false;
             }
 
-            return this.KeyTipKeys.Any(x => x == realKey);
+            var isShowOrHideKey = this.KeyTipKeys.Any(x => x == realKey);
+
+            var modifierKeys = new[]
+            {
+                Key.LeftShift,
+                Key.RightShift,
+                Key.LeftCtrl,
+                Key.RightCtrl,
+                Key.LeftAlt,
+                Key.RightAlt,
+            };
+
+            var blacklistedModifierKeys = modifierKeys
+                .Except(this.KeyTipKeys)
+                .ToArray();
+
+            var blacklistedKeyPressed = blacklistedModifierKeys.Any(Keyboard.IsKeyDown);
+            return isShowOrHideKey && !blacklistedKeyPressed;
         }
 
         private void ClearUserInput()


### PR DESCRIPTION
This fixes that if the key "alt gr" is pressed for about 1-2 secs and then another key e.g. "\" on a germany keyboard layout is pressed the backslash is not correctly routed to a text input but gets processed by the keytip service.

steps to reproduce:
- open the showcase app 
- select the tab "Tests" and click into the "KeyTip issues" textbox
- hold down "Alt Gr" for about 2 seconds
- try to enter any letter reachable via Alt Gr [e.g. a backslash "\"]

if i should create an issue or if you want me to change the source code of this pull request feel free to contact me, i'm happy to change it according to your specs :)