### PR TITLE
Made buttons work properly with screen readers v2

### DIFF
--- a/Fluent.Ribbon/Automation/FluentButtonAutomationPeer.cs
+++ b/Fluent.Ribbon/Automation/FluentButtonAutomationPeer.cs
@@ -34,7 +34,22 @@ namespace Fluent
         /// <inheritdoc />
         protected override string GetNameCore()
         {
-            return ((IHeaderedControl)this.Owner).Header?.ToString();
+            string result = base.GetNameCore();
+            if (string.IsNullOrEmpty(result))
+            {
+                AutomationPeer labelAutomationPeer = this.GetLabeledByCore();
+                if (labelAutomationPeer != null)
+                {
+                    result = labelAutomationPeer.GetName();
+                }
+
+                if (string.IsNullOrEmpty(result))
+                {
+                    result = ((IHeaderedControl)this.Owner).Header?.ToString();
+                }
+            }
+
+            return result ?? string.Empty;
         }
     }
 }

--- a/Fluent.Ribbon/Automation/FluentButtonAutomationPeer.cs
+++ b/Fluent.Ribbon/Automation/FluentButtonAutomationPeer.cs
@@ -1,0 +1,40 @@
+﻿// ReSharper disable once CheckNamespace
+namespace Fluent
+{
+    using System.Windows;
+    using System.Windows.Automation.Peers;
+    using JetBrains.Annotations;
+
+    /// <summary>
+    /// Automation peer for dropdown button.
+    /// </summary>
+    public class FluentButtonAutomationPeer : FrameworkElementAutomationPeer
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FluentButtonAutomationPeer"/> class.
+        /// </summary>
+        /// <param name="owner">The class's owner.</param>
+        public FluentButtonAutomationPeer([NotNull] FrameworkElement owner) 
+            : base(owner)
+        {
+        }
+
+        /// <inheritdoc />
+        protected override string GetClassNameCore()
+        {
+            return "FluentButton";
+        }
+
+        /// <inheritdoc />
+        protected override AutomationControlType GetAutomationControlTypeCore()
+        {
+            return AutomationControlType.Button;
+        }
+
+        /// <inheritdoc />
+        protected override string GetNameCore()
+        {
+            return ((IHeaderedControl)this.Owner).Header?.ToString();
+        }
+    }
+}

--- a/Fluent.Ribbon/Automation/FluentDropDownButtonAutomationPeer.cs
+++ b/Fluent.Ribbon/Automation/FluentDropDownButtonAutomationPeer.cs
@@ -3,18 +3,19 @@ namespace Fluent
 {
     using System.Windows;
     using System.Windows.Automation.Peers;
+    using System.Windows.Controls;
     using JetBrains.Annotations;
 
     /// <summary>
-    /// Automation peer for button.
+    /// Automation peer for dropdown button.
     /// </summary>
-    public class FluentButtonAutomationPeer : ButtonAutomationPeer
+    public class FluentDropDownButtonAutomationPeer : FrameworkElementAutomationPeer
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="FluentButtonAutomationPeer"/> class.
+        /// Initializes a new instance of the <see cref="FluentDropDownButtonAutomationPeer"/> class.
         /// </summary>
         /// <param name="owner">The class's owner.</param>
-        public FluentButtonAutomationPeer([NotNull] System.Windows.Controls.Button owner) 
+        public FluentDropDownButtonAutomationPeer([NotNull] FrameworkElement owner) 
             : base(owner)
         {
         }
@@ -22,7 +23,13 @@ namespace Fluent
         /// <inheritdoc />
         protected override string GetClassNameCore()
         {
-            return "FluentButton";
+            return "FluentDropDownButton";
+        }
+
+        /// <inheritdoc />
+        protected override AutomationControlType GetAutomationControlTypeCore()
+        {
+            return AutomationControlType.Button;
         }
 
         /// <inheritdoc />

--- a/Fluent.Ribbon/Automation/FluentToggleButtonAutomationPeer.cs
+++ b/Fluent.Ribbon/Automation/FluentToggleButtonAutomationPeer.cs
@@ -1,20 +1,20 @@
 ﻿// ReSharper disable once CheckNamespace
 namespace Fluent
 {
-    using System.Windows;
     using System.Windows.Automation.Peers;
+    using System.Windows.Controls.Primitives;
     using JetBrains.Annotations;
 
     /// <summary>
-    /// Automation peer for button.
+    /// Automation peer for toggle button.
     /// </summary>
-    public class FluentButtonAutomationPeer : ButtonAutomationPeer
+    public class FluentToggleButtonAutomationPeer : ToggleButtonAutomationPeer
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="FluentButtonAutomationPeer"/> class.
+        /// Initializes a new instance of the <see cref="FluentToggleButtonAutomationPeer"/> class.
         /// </summary>
         /// <param name="owner">The class's owner.</param>
-        public FluentButtonAutomationPeer([NotNull] System.Windows.Controls.Button owner) 
+        public FluentToggleButtonAutomationPeer([NotNull] ToggleButton owner) 
             : base(owner)
         {
         }
@@ -22,7 +22,7 @@ namespace Fluent
         /// <inheritdoc />
         protected override string GetClassNameCore()
         {
-            return "FluentButton";
+            return "FluentToggleButton";
         }
 
         /// <inheritdoc />

--- a/Fluent.Ribbon/Controls/Button.cs
+++ b/Fluent.Ribbon/Controls/Button.cs
@@ -2,6 +2,7 @@
 namespace Fluent
 {
     using System.Windows;
+    using System.Windows.Automation.Peers;
     using System.Windows.Markup;
     using Fluent.Internal.KnownBoxes;
 
@@ -211,6 +212,16 @@ namespace Fluent
         /// <inheritdoc />
         public void OnKeyTipBack()
         {
+        }
+
+        #endregion
+
+        #region UI Automation
+
+        /// <inheritdoc />
+        protected override AutomationPeer OnCreateAutomationPeer()
+        {
+            return new FluentButtonAutomationPeer(this);
         }
 
         #endregion

--- a/Fluent.Ribbon/Controls/DropDownButton.cs
+++ b/Fluent.Ribbon/Controls/DropDownButton.cs
@@ -7,6 +7,7 @@ namespace Fluent
     using System.Diagnostics;
     using System.Threading.Tasks;
     using System.Windows;
+    using System.Windows.Automation.Peers;
     using System.Windows.Controls;
     using System.Windows.Controls.Primitives;
     using System.Windows.Data;
@@ -846,6 +847,16 @@ namespace Fluent
                 }
             }
         }
+
+        #region UI Automation
+
+        /// <inheritdoc />
+        protected override AutomationPeer OnCreateAutomationPeer()
+        {
+            return new FluentButtonAutomationPeer(this);
+        }
+
+        #endregion
 
         #region MenuItem workarounds
 

--- a/Fluent.Ribbon/Controls/DropDownButton.cs
+++ b/Fluent.Ribbon/Controls/DropDownButton.cs
@@ -853,7 +853,7 @@ namespace Fluent
         /// <inheritdoc />
         protected override AutomationPeer OnCreateAutomationPeer()
         {
-            return new FluentButtonAutomationPeer(this);
+            return new FluentDropDownButtonAutomationPeer(this);
         }
 
         #endregion

--- a/Fluent.Ribbon/Controls/SplitButton.cs
+++ b/Fluent.Ribbon/Controls/SplitButton.cs
@@ -568,7 +568,7 @@ namespace Fluent
         /// <inheritdoc />
         protected override AutomationPeer OnCreateAutomationPeer()
         {
-            return new FluentButtonAutomationPeer(this);
+            return new FluentDropDownButtonAutomationPeer(this);
         }
 
         #endregion

--- a/Fluent.Ribbon/Controls/SplitButton.cs
+++ b/Fluent.Ribbon/Controls/SplitButton.cs
@@ -5,6 +5,7 @@ namespace Fluent
     using System.Collections.Generic;
     using System.ComponentModel;
     using System.Windows;
+    using System.Windows.Automation.Peers;
     using System.Windows.Controls.Primitives;
     using System.Windows.Data;
     using System.Windows.Input;
@@ -559,6 +560,16 @@ namespace Fluent
         }
 
         #endregion
+
+        #endregion
+
+        #region UI Automation
+
+        /// <inheritdoc />
+        protected override AutomationPeer OnCreateAutomationPeer()
+        {
+            return new FluentButtonAutomationPeer(this);
+        }
 
         #endregion
     }

--- a/Fluent.Ribbon/Controls/ToggleButton.cs
+++ b/Fluent.Ribbon/Controls/ToggleButton.cs
@@ -2,6 +2,7 @@
 namespace Fluent
 {
     using System.Windows;
+    using System.Windows.Automation.Peers;
     using System.Windows.Data;
     using System.Windows.Markup;
     using Fluent.Internal.KnownBoxes;
@@ -264,6 +265,16 @@ namespace Fluent
         /// <inheritdoc />
         public void OnKeyTipBack()
         {
+        }
+
+        #endregion
+
+        #region UI Automation
+
+        /// <inheritdoc />
+        protected override AutomationPeer OnCreateAutomationPeer()
+        {
+            return new FluentButtonAutomationPeer(this);
         }
 
         #endregion

--- a/Fluent.Ribbon/Controls/ToggleButton.cs
+++ b/Fluent.Ribbon/Controls/ToggleButton.cs
@@ -274,7 +274,7 @@ namespace Fluent
         /// <inheritdoc />
         protected override AutomationPeer OnCreateAutomationPeer()
         {
-            return new FluentButtonAutomationPeer(this);
+            return new FluentToggleButtonAutomationPeer(this);
         }
 
         #endregion


### PR DESCRIPTION
Updated to allow AutomationProperties.Name and AutomationProperties.LabeledBy to override the base name. This code is based on the FrameworkElementElementAutomationPeer:

https://referencesource.microsoft.com/#PresentationFramework/src/Framework/System/Windows/Automation/Peers/FrameworkElementAutomationPeer.cs,cb32f8ab388a9036