### PR TITLE
Add null check for Application.Current

### DIFF
--- a/Fluent.Ribbon/ThemeManager/ThemeManager.cs
+++ b/Fluent.Ribbon/ThemeManager/ThemeManager.cs
@@ -374,10 +374,21 @@ namespace Fluent
         /// <returns>The resource object or null, if the resource wasn't found.</returns>
         public static object GetResourceFromAppStyle(Window window, string key)
         {
-            var appStyle = (window.IsNull()
+            Theme appStyle;
+
+            if (Application.Current.IsNull()) // In case the Window is hosted in a WinForm app
+            {
+                appStyle = !window.IsNull()
+                                ? DetectTheme(window)
+                                : null;
+            }
+            else
+            {
+                appStyle = (window.IsNull()
                                 ? DetectTheme(Application.Current)
                                 : DetectTheme(window))
-                           ?? DetectTheme(Application.Current);
+                            ?? DetectTheme(Application.Current);
+            }
 
             var resource = appStyle?.Resources[key];
 
@@ -786,8 +797,9 @@ namespace Fluent
                 }
             }
 
-            // ReSharper disable once AssignNullToNotNullAttribute
-            return DetectTheme(Application.Current);
+            return Application.Current != null // In case the Window is hosted in a WinForm app
+                ? DetectTheme(Application.Current)
+                : null;
         }
 
         /// <summary>
@@ -804,7 +816,9 @@ namespace Fluent
             }
 
             var detectedStyle = DetectTheme(window.Resources)
-                                ?? DetectTheme(Application.Current.Resources);
+                                ?? (Application.Current != null // In case the Window is hosted in a WinForm app
+                                    ? DetectTheme(Application.Current.Resources)
+                                    : null);
 
             return detectedStyle;
         }
@@ -937,7 +951,10 @@ namespace Fluent
                                ? BaseColorLight
                                : BaseColorDark;
 
-            ChangeThemeBaseColor(Application.Current, baseColor);
+            if (Application.Current != null) // In case the Window is hosted in a WinForm app
+            {
+                ChangeThemeBaseColor(Application.Current, baseColor);
+            }
         }
 
         private static bool isAutomaticWindowsAppModeSettingSyncEnabled;


### PR DESCRIPTION
Add null checks for usage of Application.Current in the main part of the library. Note that the demo and the unit tests haven't been updated as they are unlikely to be used wrapped in a WinForm App.

Fix #729