### PR TITLE
Improve Visual Studio 'Clean' command behaviour: delete any generated color scheme XAML files

### DIFF
--- a/Fluent.Ribbon/Fluent.Ribbon.csproj
+++ b/Fluent.Ribbon/Fluent.Ribbon.csproj
@@ -65,4 +65,20 @@
     <!-- Combine xaml files -->
     <Exec Command="&quot;$(XamlCombinePath)&quot; &quot;Styles.txt&quot; &quot;Styles.xaml&quot;" WorkingDirectory="$(MSBuildProjectDirectory)/Themes" />
   </Target>
+
+  <!-- 
+  Delete generated color scheme XAML files when user explicitly executes Build>Clean
+  command in Visual Studio.
+  
+  https://stackoverflow.com/questions/5102661/need-a-post-clean-event-in-visual-studio 
+  -->
+  <Target Name="MyDistClean" AfterTargets="Clean">
+    <ItemGroup>
+      <ThemeFiles Include="$(MSBuildProjectDirectory)/Themes/Themes/Dark.*" />
+      <ThemeFiles Include="$(MSBuildProjectDirectory)/Themes/Themes/Light.*" />
+      <ThemeFiles Include="$(MSBuildProjectDirectory)/Themes/Themes/Colorful.*" />
+    </ItemGroup>
+    <Message Text="Deleting XAML Color Scheme files..." Importance="high" />
+    <Delete Files="$(ThemeFiles)" ContinueOnError="true" />
+  </Target>
 </Project>


### PR DESCRIPTION
Delete generated color scheme XAML files when user explicitly executes Build->Clean command in Visual Studio.

See also https://stackoverflow.com/questions/5102661/need-a-post-clean-event-in-visual-studio

---

Thanks for Fluent.Ribbon, BTW. 👍 