### PR TITLE
fix crash in Showcase demo app when you don't have the `snoop` executable

### DIFF
--- a/Fluent.Ribbon.Showcase/TestContent.xaml.cs
+++ b/Fluent.Ribbon.Showcase/TestContent.xaml.cs
@@ -595,7 +595,14 @@ namespace FluentTest
             }
 
             var startInfo = new ProcessStartInfo(snoopPath, $"inspect --targetPID {Process.GetCurrentProcess().Id}");
-            using var p = Process.Start(startInfo);
+            try
+            {
+                using var p = Process.Start(startInfo);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Error: {ex.Message}\n\nCommandline: {startInfo.FileName} {startInfo.Arguments}");
+            }
         }
     }
 


### PR DESCRIPTION
fix crash in Showcase app when you don't have the `snoop` executable around, which is invoked when you go to the tab Developers->Snoop in the Showcase app.

Show alert box with error report and commandline.