### PR TITLE
fix invoke vs interface mismatch: the test code refused to compile & execute

### DIFF
--- a/Fluent.Ribbon.Tests/Internal/WhenLoadedTests.cs
+++ b/Fluent.Ribbon.Tests/Internal/WhenLoadedTests.cs
@@ -17,7 +17,7 @@
 
             using (new TestRibbonWindow(control))
             {
-                control.WhenLoaded(x => ++loadedActionCallCount);
+                WhenLoadedExtension.WhenLoaded(control, x => ++loadedActionCallCount);
 
                 Assert.That(loadedActionCallCount, Is.EqualTo(1));
             }

--- a/Fluent.Ribbon/Properties/AssemblyInfo.cs
+++ b/Fluent.Ribbon/Properties/AssemblyInfo.cs
@@ -11,5 +11,6 @@ using System.Windows.Markup;
 [assembly: XmlnsDefinition("urn:fluent-ribbon", "Fluent.Theming")]
 [assembly: XmlnsDefinition("urn:fluent-ribbon", "Fluent.Metro.Behaviours")]
 
-[assembly: InternalsVisibleTo("Fluent.Ribbon.Showcase, PublicKey=002400000480000094000000060200000024000052534131000400000100010003e4bf649b00e91e7ba00628cbf54e2f97c2c9c547d8740534a57224c42e2ebdb28bac992119794a76c50f1a7f88c7af3203a4bb59501d40e10e9b6ec302d5fca6f23c0f8e800eaf5cc6f7ac682e6c50641a74b09e2e80d1905b01fd8707daacf10708faf7193233378fa909f211e77e0e7fa066e037a0c087d4b74ecf0467ae")]
-[assembly: InternalsVisibleTo("Fluent.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010003e4bf649b00e91e7ba00628cbf54e2f97c2c9c547d8740534a57224c42e2ebdb28bac992119794a76c50f1a7f88c7af3203a4bb59501d40e10e9b6ec302d5fca6f23c0f8e800eaf5cc6f7ac682e6c50641a74b09e2e80d1905b01fd8707daacf10708faf7193233378fa909f211e77e0e7fa066e037a0c087d4b74ecf0467ae")]
+// Allow internals to be accessible by the unit test code:
+[assembly: InternalsVisibleTo("Fluent.Ribbon.Showcase")]
+[assembly: InternalsVisibleTo("Fluent.Tests")]


### PR DESCRIPTION
- fix invoke vs interface mismatch: the test code refused to compile & execute as the WhenLoaded module/class/extension interface does not match the way it is invoked in the test code.

- fix Visual Studio error report about test project *not* having access to the internals of the fluent.Ribbon library: nuke the public key.

## Reason for patch

My VS2019 barfed at build time due to the mismatch between test code and module itself. Happened with latest bleeding edge code base.

The 'nuke public key' action was a quick fix for the trouble that showed up afterwards: now that the test code was fixed, VS2019 complained loudly about the test rig **not** having been granted access to the Fluent.Ribbon internals *despite* the settings. Which led me to inspect those lines and remove anything that looks like being possibly too strict for me as average Joe Dev on his way to compile and run Fluent.Ribbon from source. 😉 

Anyway, if you don't want that bit, you can always cherrypick the first commit from this patch/pullreq.

Cheers.

