### PR TITLE
Implement for #931 (support StateDefinition property of RibbonGroupBox)

### DIFF
--- a/Fluent.Ribbon.Showcase/TestContent.xaml
+++ b/Fluent.Ribbon.Showcase/TestContent.xaml
@@ -23,7 +23,7 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="pack://application:,,,/Fluent.Ribbon.Showcase;component/Images/VectorIcons.xaml" />
             </ResourceDictionary.MergedDictionaries>
-            
+
             <BooleanToVisibilityConverter x:Key="boolToVisibilityConverter" />
             <converters:UniqueGroupNameConverter x:Key="UniqueGroupNameConverter" />
 
@@ -90,7 +90,7 @@
                     </StackPanel>
                 </Border>
             </DataTemplate>
-            
+
             <DataTemplate x:Key="GallerySampleDataItemCommandTemplate"
                           DataType="{x:Type viewModels:GallerySampleDataItemViewModel}">
                 <Fluent:Button Header="{Binding Text}"
@@ -168,7 +168,7 @@
                     <!--Backstage items can be keytipped-->
                     <Fluent:Backstage x:Name="Backstage"
                                       Visibility="Collapsed">
-                        
+
                         <!--<Fluent:Backstage.Style>
                             <Style TargetType="Fluent:Backstage">
                                 <Style.Triggers>
@@ -204,17 +204,17 @@
                                         <Fluent:Button Header="Button with bound command"
                                                        Width="120"
                                                        Command="{Binding TestCommand}" />
-                                    
+
                                         <Fluent:Button Header="Button"
                                                        IsDefinitive="False"
                                                        Click="HandleShowMetroMessage"
                                                        Icon="{DynamicResource Fluent.Ribbon.Images.Paste}"
                                                        LargeIcon="{DynamicResource Fluent.Ribbon.Images.Paste}" />
-                                    
+
                                         <Fluent:ToggleButton Header="Toggle"
                                                              Icon="{DynamicResource Fluent.Ribbon.Images.Paste}"
                                                              LargeIcon="{DynamicResource Fluent.Ribbon.Images.Paste}" />
-                                    
+
                                         <Fluent:DropDownButton Header="DropDownButton"
                                                                Icon="{DynamicResource Fluent.Ribbon.Images.Paste}"
                                                                LargeIcon="{DynamicResource Fluent.Ribbon.Images.Paste}"
@@ -229,14 +229,14 @@
                                             <TextBlock Text="4" />
                                             <TextBlock Text="5" />
                                         </Fluent:ComboBox>
-                                    
+
                                         <Fluent:Spinner Value="1"
                                                         Format="0"
                                                         InputWidth="50"
                                                         Header="Spinner"
                                                         ValueChanged="OnSpinnerValueChanged" />
                                     </WrapPanel>
-                                    
+
                                     <TextBlock TextWrapping="Wrap">
                                         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer mi elit, efficitur a sapien sit amet, euismod tempus quam. Aenean porta nisl id erat eleifend, vehicula convallis orci posuere. Maecenas id eleifend magna. Aenean quis nunc id odio tristique scelerisque et eu felis. Donec vestibulum augue sit amet dignissim feugiat. Pellentesque dignissim maximus lacinia. Maecenas dictum velit ut dui tempor imperdiet.
 
@@ -434,7 +434,7 @@ Pellentesque nec dolor sed lacus tristique rutrum sed vitae urna. Sed eu pharetr
 
             <Fluent:RibbonTabItem Header="Toolbars"
                                   KeyTip="TO"
-                                  ReduceOrder="Group2, Group2, Group2, Font, Font, Font, Font,B,A,A,A,(A),(A),(A),Clipboard,Font,B,B,(A),C,(A),(A)">
+                                  ReduceOrder="Clipboard,Clipboard,Group, Group, Group, Font, Font, Font, Font,B,A,A,A,(A),(A),(A),Clipboard,Font,B,B,(A),C,(A),(A)">
                 <Fluent:RibbonGroupBox Icon="{DynamicResource Fluent.Ribbon.Images.DefaultPlaceholder}"
                                        KeyTip="C"
                                        x:Name="Clipboard"
@@ -744,6 +744,7 @@ Pellentesque nec dolor sed lacus tristique rutrum sed vitae urna. Sed eu pharetr
                 <Fluent:RibbonGroupBox KeyTip="F"
                                        x:Name="Font"
                                        Header="Font"
+                                       StateDefinition="Large,Middle,Small"
                                        IsLauncherVisible="True"
                                        LauncherClick="OnLauncherButtonClick"
                                        Icon="pack://application:,,,/Fluent.Ribbon.Showcase;component/Images/FontColor.png"
@@ -1030,7 +1031,8 @@ Pellentesque nec dolor sed lacus tristique rutrum sed vitae urna. Sed eu pharetr
                     </Fluent:RibbonToolBar>
                 </Fluent:RibbonGroupBox>
                 
-                <Fluent:RibbonGroupBox Header="Group">
+                <Fluent:RibbonGroupBox x:Name="Group"
+                                       Header="Group">
                     <Fluent:RibbonToolBar>
                         <!--ToolBar Layout Definitions-->
                         <Fluent:RibbonToolBar.LayoutDefinitions>
@@ -1131,7 +1133,7 @@ Pellentesque nec dolor sed lacus tristique rutrum sed vitae urna. Sed eu pharetr
                                     Icon="{DynamicResource Fluent.Ribbon.Images.Warning}" />
                 </Fluent:RibbonGroupBox>
             </Fluent:RibbonTabItem>
-            
+
             <Fluent:RibbonTabItem Header="Insert"
                                   KeyTip="I"
                                   IsSeparatorVisible="true"
@@ -1188,7 +1190,7 @@ Pellentesque nec dolor sed lacus tristique rutrum sed vitae urna. Sed eu pharetr
                         <System:String>Read-only</System:String>
                         <System:String>Writeable</System:String>
                     </Fluent:ComboBox>
-                    
+
                     <Fluent:ComboBox Header="KeyboardNavigation" 
                                      IsEditable="False"
                                      IsReadOnly="True"
@@ -1880,7 +1882,7 @@ Pellentesque nec dolor sed lacus tristique rutrum sed vitae urna. Sed eu pharetr
                                         IsCheckable="True"
                                         GroupName="{Binding Converter={StaticResource UniqueGroupNameConverter},ConverterParameter=Group2}" />
                 </Fluent:RibbonGroupBox>
-               
+
                 <Fluent:RibbonGroupBox Header="Grouped ToggleButton">
                     <Fluent:ToggleButton Header="Toggle 1"
                                          KeyTip="T1"
@@ -2640,7 +2642,7 @@ Pellentesque nec dolor sed lacus tristique rutrum sed vitae urna. Sed eu pharetr
                                    Fluent:KeyTip.HorizontalAlignment="Left"
                                    Fluent:KeyTip.VerticalAlignment="Top"
                                    Fluent:KeyTip.Margin="40,0,0,0"
-                                   Fluent:KeyTip.Keys="LTM" />                    
+                                   Fluent:KeyTip.Keys="LTM" />
                 </Fluent:RibbonGroupBox>
             </Fluent:RibbonTabItem>
 
@@ -2725,7 +2727,7 @@ Pellentesque nec dolor sed lacus tristique rutrum sed vitae urna. Sed eu pharetr
                     <Setter Property="BorderThickness"
                             Value="1" />
                 </Style>
-                
+
                 <Style x:Key="TabItemFocusVisual">
                     <Setter Property="Control.Template">
                         <Setter.Value>
@@ -2739,10 +2741,10 @@ Pellentesque nec dolor sed lacus tristique rutrum sed vitae urna. Sed eu pharetr
                         </Setter.Value>
                     </Setter>
                 </Style>
-                
+
                 <SolidColorBrush x:Key="TabControlNormalBorderBrush"
                                  Color="#8C8E94"/>
-                
+
                 <SolidColorBrush x:Key="TabItemHotBackground"
                                  Color="{DynamicResource Fluent.Ribbon.Colors.AccentColor60}"/>
                 <SolidColorBrush x:Key="TabItemSelectedBackground"
@@ -2900,11 +2902,11 @@ Pellentesque nec dolor sed lacus tristique rutrum sed vitae urna. Sed eu pharetr
                     </Setter>
                 </Style>
             </TabControl.Resources>
-            
+
             <TabItem Header="Home">
                 <ScrollViewer>
-                <StackPanel>
-                    <TextBlock TextWrapping="Wrap">
+                    <StackPanel>
+                        <TextBlock TextWrapping="Wrap">
                         <Run FontWeight="ExtraBold"
                              FontSize="18">Fluent.Ribbon</Run>
                         <LineBreak />
@@ -2913,42 +2915,42 @@ Pellentesque nec dolor sed lacus tristique rutrum sed vitae urna. Sed eu pharetr
                         It provides controls such as RibbonTabControl, Backstage, Gallery, QuickAccessToolbar, ScreenTip and so on.
                         <LineBreak />
                         <LineBreak />
-                    </TextBlock>
+                        </TextBlock>
 
-                    <GroupBox Header="Options">
-                        <WrapPanel>
-                            <GroupBox Header="Theme">
-                                <WrapPanel>
-                                    <WrapPanel.Resources>
-                                        <ObjectDataProvider MethodName="GetValues"
+                        <GroupBox Header="Options">
+                            <WrapPanel>
+                                <GroupBox Header="Theme">
+                                    <WrapPanel>
+                                        <WrapPanel.Resources>
+                                            <ObjectDataProvider MethodName="GetValues"
                                                             ObjectType="{x:Type controlzEx:ThemeSyncMode}"
                                                             x:Key="SyncModePreferenceEnumValues">
-                                            <ObjectDataProvider.MethodParameters>
-                                                <x:Type TypeName="controlzEx:ThemeSyncMode" />
-                                            </ObjectDataProvider.MethodParameters>
-                                        </ObjectDataProvider>
-                                    </WrapPanel.Resources>
-                                    <Fluent:ComboBox Header="BaseColors"
+                                                <ObjectDataProvider.MethodParameters>
+                                                    <x:Type TypeName="controlzEx:ThemeSyncMode" />
+                                                </ObjectDataProvider.MethodParameters>
+                                            </ObjectDataProvider>
+                                        </WrapPanel.Resources>
+                                        <Fluent:ComboBox Header="BaseColors"
                                                      MinWidth="140"
                                                      IsEditable="False"
                                                      ItemsSource="{Binding Source={x:Static controlzEx:ThemeManager.Current}, Path=BaseColors}"
                                                      SelectedItem="{Binding ColorViewModel.CurrentBaseColor, Mode=TwoWay}" />
-                                    <Fluent:ComboBox Header="Theme"
+                                        <Fluent:ComboBox Header="Theme"
                                                      MinWidth="150"
                                                      IsEditable="False"
                                                      ItemsSource="{Binding Source={x:Static controlzEx:ThemeManager.Current}, Path=Themes}"
                                                      SelectedItem="{Binding ColorViewModel.CurrentTheme, Mode=TwoWay}">
-                                        <Fluent:ComboBox.ItemTemplate>
-                                            <DataTemplate DataType="{x:Type controlzEx:Theme}">
-                                                <StackPanel Orientation="Horizontal">
-                                                    <Ellipse Width="16"
+                                            <Fluent:ComboBox.ItemTemplate>
+                                                <DataTemplate DataType="{x:Type controlzEx:Theme}">
+                                                    <StackPanel Orientation="Horizontal">
+                                                        <Ellipse Width="16"
                                                              Height="16"
                                                              Fill="{Binding ShowcaseBrush, Mode=OneWay}" />
-                                                    <TextBlock Text="{Binding DisplayName}" />
-                                                </StackPanel>
-                                            </DataTemplate>
-                                        </Fluent:ComboBox.ItemTemplate>
-                                        <!--<Fluent:ComboBox.GroupStyle>
+                                                        <TextBlock Text="{Binding DisplayName}" />
+                                                    </StackPanel>
+                                                </DataTemplate>
+                                            </Fluent:ComboBox.ItemTemplate>
+                                            <!--<Fluent:ComboBox.GroupStyle>
                                             <GroupStyle>
                                                 <GroupStyle.HeaderTemplate>
                                                     <DataTemplate>
@@ -2961,198 +2963,198 @@ Pellentesque nec dolor sed lacus tristique rutrum sed vitae urna. Sed eu pharetr
                                                 </GroupStyle.HeaderTemplate>
                                             </GroupStyle>
                                         </Fluent:ComboBox.GroupStyle>-->
-                                    </Fluent:ComboBox>
+                                        </Fluent:ComboBox>
 
-                                    <Fluent:ComboBox Header="SyncMode"
+                                        <Fluent:ComboBox Header="SyncMode"
                                                      IsEditable="False"
                                                      ItemsSource="{Binding Source={StaticResource SyncModePreferenceEnumValues}}"
                                                      SelectedItem="{Binding Source={x:Static controlzEx:ThemeManager.Current}, Path=ThemeSyncMode}" />
-                                    <Fluent:CheckBox IsChecked="{Binding Path=Options.UseHSL, Source={x:Static controlzEx:RuntimeThemeGenerator.Current}, Mode=TwoWay}"
+                                        <Fluent:CheckBox IsChecked="{Binding Path=Options.UseHSL, Source={x:Static controlzEx:RuntimeThemeGenerator.Current}, Mode=TwoWay}"
                                                      Header="Use HSL color" />
-                                    <Button Click="SyncThemeNow_OnClick">Sync now</Button>
-                                </WrapPanel>
-                            </GroupBox>
+                                        <Button Click="SyncThemeNow_OnClick">Sync now</Button>
+                                    </WrapPanel>
+                                </GroupBox>
 
-                            <GroupBox Header="WindowGlow">
-                                <WrapPanel>
-                                    <Fluent:ComboBox Header="GlowBrush"
+                                <GroupBox Header="WindowGlow">
+                                    <WrapPanel>
+                                        <Fluent:ComboBox Header="GlowBrush"
                                                      MinWidth="140"
                                                      IsEditable="False"
                                                      ItemsSource="{Binding Brushes, ElementName=TestContentControl}"
                                                      SelectedValuePath="Value"
                                                      SelectedValue="{Binding Path=GlowBrush, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
-                                        <Fluent:ComboBox.ItemTemplate>
-                                            <DataTemplate>
-                                                <Grid>
-                                                    <Grid.ColumnDefinitions>
-                                                        <ColumnDefinition Width="Auto" />
-                                                        <ColumnDefinition Width="*" />
-                                                    </Grid.ColumnDefinitions>
-                                                    <Grid Grid.Column="0"
+                                            <Fluent:ComboBox.ItemTemplate>
+                                                <DataTemplate>
+                                                    <Grid>
+                                                        <Grid.ColumnDefinitions>
+                                                            <ColumnDefinition Width="Auto" />
+                                                            <ColumnDefinition Width="*" />
+                                                        </Grid.ColumnDefinitions>
+                                                        <Grid Grid.Column="0"
                                                           Margin="4 0"
                                                           Width="{Binding RelativeSource={RelativeSource Self}, Path=ActualHeight}"
                                                           VerticalAlignment="Stretch"
                                                           Background="{Binding Value}" />
-                                                    <TextBlock Grid.Column="1"
+                                                        <TextBlock Grid.Column="1"
                                                                Margin="4 0"
                                                                Text="{Binding}" />
-                                                </Grid>
-                                            </DataTemplate>
-                                        </Fluent:ComboBox.ItemTemplate>
-                                    </Fluent:ComboBox>
+                                                    </Grid>
+                                                </DataTemplate>
+                                            </Fluent:ComboBox.ItemTemplate>
+                                        </Fluent:ComboBox>
 
-                                    <Fluent:ComboBox Header="NonActiveGlowBrush"
+                                        <Fluent:ComboBox Header="NonActiveGlowBrush"
                                                      MinWidth="150"
                                                      IsEditable="False"
                                                      ItemsSource="{Binding Brushes, ElementName=TestContentControl}"
                                                      SelectedValuePath="Value"
                                                      SelectedValue="{Binding Path=NonActiveGlowBrush, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type Window}}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
-                                        <Fluent:ComboBox.ItemTemplate>
-                                            <DataTemplate>
-                                                <Grid>
-                                                    <Grid.ColumnDefinitions>
-                                                        <ColumnDefinition Width="Auto" />
-                                                        <ColumnDefinition Width="*" />
-                                                    </Grid.ColumnDefinitions>
-                                                    <Grid Grid.Column="0"
+                                            <Fluent:ComboBox.ItemTemplate>
+                                                <DataTemplate>
+                                                    <Grid>
+                                                        <Grid.ColumnDefinitions>
+                                                            <ColumnDefinition Width="Auto" />
+                                                            <ColumnDefinition Width="*" />
+                                                        </Grid.ColumnDefinitions>
+                                                        <Grid Grid.Column="0"
                                                           Margin="4 0"
                                                           Width="{Binding RelativeSource={RelativeSource Self}, Path=ActualHeight}"
                                                           VerticalAlignment="Stretch"
                                                           Background="{Binding Value}" />
-                                                    <TextBlock Grid.Column="1"
+                                                        <TextBlock Grid.Column="1"
                                                                Margin="4 0"
                                                                Text="{Binding}" />
-                                                </Grid>
-                                            </DataTemplate>
-                                        </Fluent:ComboBox.ItemTemplate>
-                                    </Fluent:ComboBox>
-                                </WrapPanel>
-                            </GroupBox>
+                                                    </Grid>
+                                                </DataTemplate>
+                                            </Fluent:ComboBox.ItemTemplate>
+                                        </Fluent:ComboBox>
+                                    </WrapPanel>
+                                </GroupBox>
 
-                            <GroupBox Header="Menu">
-                                <WrapPanel>
-                                    <Fluent:ComboBox Header="Menu" 
+                                <GroupBox Header="Menu">
+                                    <WrapPanel>
+                                        <Fluent:ComboBox Header="Menu" 
                                                      IsEditable="False"
                                                      SizeDefinition="Middle" 
                                                      SelectedItem="{Binding SelectedMenu, ElementName=TestContentControl}">
-                                        <System:String>ApplicationMenu</System:String>
-                                        <System:String>Backstage</System:String>
-                                        <System:String>Empty menu</System:String>
-                                    </Fluent:ComboBox>
+                                            <System:String>ApplicationMenu</System:String>
+                                            <System:String>Backstage</System:String>
+                                            <System:String>Empty menu</System:String>
+                                        </Fluent:ComboBox>
 
-                                    <Fluent:Button Name="ShowStartScreen"
+                                        <Fluent:Button Name="ShowStartScreen"
                                                    Size="Middle"
                                                    Click="ShowStartScreen_OnClick">
-                                        Show start screen
-                                    </Fluent:Button>
-                                </WrapPanel>
-                            </GroupBox>
+                                            Show start screen
+                                        </Fluent:Button>
+                                    </WrapPanel>
+                                </GroupBox>
 
-                            <GroupBox Header="Localization">
-                                <WrapPanel>
-                                    <Fluent:ComboBox Header="Localization" 
+                                <GroupBox Header="Localization">
+                                    <WrapPanel>
+                                        <Fluent:ComboBox Header="Localization" 
                                                      IsEditable="False"
                                                      SizeDefinition="Middle"
                                                      DisplayMemberPath="DisplayName"
                                                      ItemsSource="{Binding Localizations, ElementName=TestContentControl}"
                                                      SelectedItem="{Binding Path=Localization, Source={x:Static Fluent:RibbonLocalization.Current}}" />
-                                </WrapPanel>
-                            </GroupBox>
+                                    </WrapPanel>
+                                </GroupBox>
 
-                            <GroupBox Header="Window options">
-                                <WrapPanel>
-                                    <Fluent:CheckBox IsChecked="{Binding IsIconVisible, RelativeSource={RelativeSource AncestorType={x:Type Fluent:RibbonWindow}}, FallbackValue=false}">
-                                        IsIconVisible
-                                    </Fluent:CheckBox>
-                                    <Fluent:CheckBox IsChecked="{Binding IsCollapsed, RelativeSource={RelativeSource AncestorType={x:Type Fluent:RibbonWindow}}, FallbackValue=false}">
-                                        IsCollapsed
-                                    </Fluent:CheckBox>
-                                    <Fluent:CheckBox IsChecked="{Binding IsAutomaticCollapseEnabled, RelativeSource={RelativeSource AncestorType={x:Type Fluent:RibbonWindow}}, FallbackValue=false}">
-                                        IsAutomaticCollapseEnabled
-                                    </Fluent:CheckBox>
-                                    <Fluent:CheckBox x:Name="IsStatusBarVisibleCheckBox"
+                                <GroupBox Header="Window options">
+                                    <WrapPanel>
+                                        <Fluent:CheckBox IsChecked="{Binding IsIconVisible, RelativeSource={RelativeSource AncestorType={x:Type Fluent:RibbonWindow}}, FallbackValue=false}">
+                                            IsIconVisible
+                                        </Fluent:CheckBox>
+                                        <Fluent:CheckBox IsChecked="{Binding IsCollapsed, RelativeSource={RelativeSource AncestorType={x:Type Fluent:RibbonWindow}}, FallbackValue=false}">
+                                            IsCollapsed
+                                        </Fluent:CheckBox>
+                                        <Fluent:CheckBox IsChecked="{Binding IsAutomaticCollapseEnabled, RelativeSource={RelativeSource AncestorType={x:Type Fluent:RibbonWindow}}, FallbackValue=false}">
+                                            IsAutomaticCollapseEnabled
+                                        </Fluent:CheckBox>
+                                        <Fluent:CheckBox x:Name="IsStatusBarVisibleCheckBox"
                                                      IsChecked="True">
-                                        IsStatusBarVisible
-                                    </Fluent:CheckBox>
-                                    <ComboBox x:Name="ResizeModeComboBox"
+                                            IsStatusBarVisible
+                                        </Fluent:CheckBox>
+                                        <ComboBox x:Name="ResizeModeComboBox"
                                               AutomationProperties.Name="Window resize mode"
                                               ItemsSource="{Binding Source={StaticResource ResizeModeEnumValues}}"
                                               SelectedItem="{Binding Path=ResizeMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, RelativeSource={RelativeSource AncestorType={x:Type Window}}}" />
 
-                                    <ComboBox x:Name="FlowDirectionComboBox"
+                                        <ComboBox x:Name="FlowDirectionComboBox"
                                               AutomationProperties.Name="Window flow direction"
                                               ItemsSource="{Binding Source={StaticResource FlowDirectionEnumValues}}"
                                               SelectedItem="{Binding Path=FlowDirection, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, RelativeSource={RelativeSource AncestorType={x:Type Window}}}" />
 
                                         <Fluent:CheckBox IsChecked="{Binding Path=IgnoreTaskbarOnMaximize, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, RelativeSource={RelativeSource AncestorType={x:Type Fluent:RibbonWindow}}, FallbackValue=False}">
-                                        IgnoreTaskbarOnMaximize
-                                    </Fluent:CheckBox>
-                                </WrapPanel>
-                            </GroupBox>
+                                            IgnoreTaskbarOnMaximize
+                                        </Fluent:CheckBox>
+                                    </WrapPanel>
+                                </GroupBox>
 
-                            <GroupBox Header="Ribbon options">
-                                <WrapPanel>
-                                    <Fluent:CheckBox IsChecked="{Binding ShowQuickAccessToolBarAboveRibbon, ElementName=ribbon}">
-                                        ShowQuickAccessToolBarAboveRibbon
-                                    </Fluent:CheckBox>
-                                    <Fluent:CheckBox IsChecked="{Binding CanCustomizeQuickAccessToolBar, ElementName=ribbon}">
-                                        CanCustomizeQuickAccessToolBar
-                                    </Fluent:CheckBox>
-                                    <Fluent:CheckBox IsChecked="{Binding CanCustomizeQuickAccessToolBarItems, ElementName=ribbon}">
-                                        CanCustomizeQuickAccessToolBarItems
-                                    </Fluent:CheckBox>
-                                    <Fluent:CheckBox IsChecked="{Binding CanCustomizeRibbon, ElementName=ribbon}">
-                                        CanCustomizeRibbon
-                                    </Fluent:CheckBox>
-                                    <Fluent:CheckBox IsChecked="{Binding IsMinimized, ElementName=ribbon}">
-                                        IsMinimized
-                                    </Fluent:CheckBox>
-                                    <Fluent:CheckBox IsChecked="{Binding CanMinimize, ElementName=ribbon}">
-                                        CanMinimize
-                                    </Fluent:CheckBox>
-                                    <Fluent:CheckBox IsChecked="{Binding IsCollapsed, ElementName=ribbon}">
-                                        IsCollapsed
-                                    </Fluent:CheckBox>
-                                    <Fluent:CheckBox IsChecked="{Binding IsAutomaticCollapseEnabled, ElementName=ribbon}">
-                                        IsAutomaticCollapseEnabled
-                                    </Fluent:CheckBox>
-                                    <Fluent:CheckBox IsChecked="{Binding IsQuickAccessToolBarVisible, ElementName=ribbon}">
-                                        IsQuickAccessToolBarVisible
-                                    </Fluent:CheckBox>
-                                    <Fluent:CheckBox IsChecked="{Binding IsQuickAccessToolBarMenuDropDownVisible , ElementName=ribbon}">
-                                        IsQuickAccessToolBarMenuDropDownVisible
-                                    </Fluent:CheckBox>                    
-                                    <Fluent:CheckBox IsChecked="{Binding CanQuickAccessLocationChanging, ElementName=ribbon}">
-                                        CanQuickAccessLocationChanging
-                                    </Fluent:CheckBox>
-                                    <Fluent:CheckBox IsChecked="{Binding AutomaticStateManagement, ElementName=ribbon}">
-                                        AutomaticStateManagement
-                                    </Fluent:CheckBox>
-                                    <Fluent:CheckBox IsChecked="{Binding AreTabHeadersVisible, ElementName=ribbon}">
-                                        AreTabHeadersVisible
-                                    </Fluent:CheckBox>
-                                    <Fluent:CheckBox IsChecked="{Binding IsToolBarVisible, ElementName=ribbon}">
-                                        IsToolBarVisible
-                                    </Fluent:CheckBox>
-                                    <Fluent:CheckBox IsChecked="{Binding IsMouseWheelScrollingEnabled, ElementName=ribbon}">
-                                        IsMouseWheelScrollingEnabled
-                                    </Fluent:CheckBox>
-                                    <Fluent:CheckBox IsChecked="{Binding IsDefaultContextMenuEnabled, ElementName=ribbon}">
-                                        IsDefaultContextMenuEnabled
-                                    </Fluent:CheckBox>
-                                </WrapPanel>
-                            </GroupBox>
+                                <GroupBox Header="Ribbon options">
+                                    <WrapPanel>
+                                        <Fluent:CheckBox IsChecked="{Binding ShowQuickAccessToolBarAboveRibbon, ElementName=ribbon}">
+                                            ShowQuickAccessToolBarAboveRibbon
+                                        </Fluent:CheckBox>
+                                        <Fluent:CheckBox IsChecked="{Binding CanCustomizeQuickAccessToolBar, ElementName=ribbon}">
+                                            CanCustomizeQuickAccessToolBar
+                                        </Fluent:CheckBox>
+                                        <Fluent:CheckBox IsChecked="{Binding CanCustomizeQuickAccessToolBarItems, ElementName=ribbon}">
+                                            CanCustomizeQuickAccessToolBarItems
+                                        </Fluent:CheckBox>
+                                        <Fluent:CheckBox IsChecked="{Binding CanCustomizeRibbon, ElementName=ribbon}">
+                                            CanCustomizeRibbon
+                                        </Fluent:CheckBox>
+                                        <Fluent:CheckBox IsChecked="{Binding IsMinimized, ElementName=ribbon}">
+                                            IsMinimized
+                                        </Fluent:CheckBox>
+                                        <Fluent:CheckBox IsChecked="{Binding CanMinimize, ElementName=ribbon}">
+                                            CanMinimize
+                                        </Fluent:CheckBox>
+                                        <Fluent:CheckBox IsChecked="{Binding IsCollapsed, ElementName=ribbon}">
+                                            IsCollapsed
+                                        </Fluent:CheckBox>
+                                        <Fluent:CheckBox IsChecked="{Binding IsAutomaticCollapseEnabled, ElementName=ribbon}">
+                                            IsAutomaticCollapseEnabled
+                                        </Fluent:CheckBox>
+                                        <Fluent:CheckBox IsChecked="{Binding IsQuickAccessToolBarVisible, ElementName=ribbon}">
+                                            IsQuickAccessToolBarVisible
+                                        </Fluent:CheckBox>
+                                        <Fluent:CheckBox IsChecked="{Binding IsQuickAccessToolBarMenuDropDownVisible , ElementName=ribbon}">
+                                            IsQuickAccessToolBarMenuDropDownVisible
+                                        </Fluent:CheckBox>
+                                        <Fluent:CheckBox IsChecked="{Binding CanQuickAccessLocationChanging, ElementName=ribbon}">
+                                            CanQuickAccessLocationChanging
+                                        </Fluent:CheckBox>
+                                        <Fluent:CheckBox IsChecked="{Binding AutomaticStateManagement, ElementName=ribbon}">
+                                            AutomaticStateManagement
+                                        </Fluent:CheckBox>
+                                        <Fluent:CheckBox IsChecked="{Binding AreTabHeadersVisible, ElementName=ribbon}">
+                                            AreTabHeadersVisible
+                                        </Fluent:CheckBox>
+                                        <Fluent:CheckBox IsChecked="{Binding IsToolBarVisible, ElementName=ribbon}">
+                                            IsToolBarVisible
+                                        </Fluent:CheckBox>
+                                        <Fluent:CheckBox IsChecked="{Binding IsMouseWheelScrollingEnabled, ElementName=ribbon}">
+                                            IsMouseWheelScrollingEnabled
+                                        </Fluent:CheckBox>
+                                        <Fluent:CheckBox IsChecked="{Binding IsDefaultContextMenuEnabled, ElementName=ribbon}">
+                                            IsDefaultContextMenuEnabled
+                                        </Fluent:CheckBox>
+                                    </WrapPanel>
+                                </GroupBox>
 
-                            <GroupBox Header="Commands">
-                                <Button Content="Reset saved state &amp; restart" 
+                                <GroupBox Header="Commands">
+                                    <Button Content="Reset saved state &amp; restart" 
                                         Click="HandleResetSavedState_OnClick" />
-                            </GroupBox>
-                        </WrapPanel>
-                    </GroupBox>
-                </StackPanel>
+                                </GroupBox>
+                            </WrapPanel>
+                        </GroupBox>
+                    </StackPanel>
                 </ScrollViewer>
             </TabItem>
-            
+
             <TabItem Header="Developer">
                 <Grid>
                     <Grid.RowDefinitions>
@@ -3244,7 +3246,7 @@ Pellentesque nec dolor sed lacus tristique rutrum sed vitae urna. Sed eu pharetr
                               MouseDoubleClick="OnTreeDoubleClick" />
                 </Grid>
             </TabItem>
-            
+
             <TabItem Header="ViewboxTest"
                      Fluent:FrameworkHelper.UseLayoutRounding="False">
                 <Grid>
@@ -3326,80 +3328,80 @@ Pellentesque nec dolor sed lacus tristique rutrum sed vitae urna. Sed eu pharetr
                     </Viewbox>
                 </Grid>
             </TabItem>
-            
+
             <TabItem Header="Tests">
                 <ScrollViewer>
-                <StackPanel Orientation="Vertical">
-                    <GroupBox Header="Tabs">
-                        <WrapPanel>
-                            <Fluent:Button x:Name="AddRibbonTab"
+                    <StackPanel Orientation="Vertical">
+                        <GroupBox Header="Tabs">
+                            <WrapPanel>
+                                <Fluent:Button x:Name="AddRibbonTab"
                                            Size="Middle"
                                            Click="AddRibbonTab_OnClick">Add tab</Fluent:Button>
-                        </WrapPanel>
-                    </GroupBox>
-                    <GroupBox Header="Interop">
-                        <WrapPanel>
-                            <Fluent:Button x:Name="OpenMahMetroWindow"
+                            </WrapPanel>
+                        </GroupBox>
+                        <GroupBox Header="Interop">
+                            <WrapPanel>
+                                <Fluent:Button x:Name="OpenMahMetroWindow"
                                            Size="Middle"
                                            Click="OpenMahMetroWindow_OnClick">Open MahMetro-Window</Fluent:Button>
-                        </WrapPanel>
-                    </GroupBox>
-                    <GroupBox Header="Windows">
-                        <WrapPanel>
-                            <Fluent:Button x:Name="OpenRegularWindow"
+                            </WrapPanel>
+                        </GroupBox>
+                        <GroupBox Header="Windows">
+                            <WrapPanel>
+                                <Fluent:Button x:Name="OpenRegularWindow"
                                            Size="Middle"
                                            Click="OpenRegularWindow_OnClick">Open Regular-Window</Fluent:Button>
-                            <Fluent:Button x:Name="OpenMinimalRibbonWindowSample"
+                                <Fluent:Button x:Name="OpenMinimalRibbonWindowSample"
                                            Size="Middle"
                                            Click="OpenMinimalRibbonWindowSample_OnClick">Open Minimal Ribbon-Window Sample</Fluent:Button>
-                            <Fluent:Button x:Name="OpenRibbonWindowWithoutVisibileRibbon"
+                                <Fluent:Button x:Name="OpenRibbonWindowWithoutVisibileRibbon"
                                            Size="Middle"
                                            Click="OpenRibbonWindowWithoutVisibileRibbon_OnClick">Open Ribbon-Window without visible Ribbon</Fluent:Button>
-                            <Fluent:Button x:Name="OpenRibbonWindowWithoutRibbon"
+                                <Fluent:Button x:Name="OpenRibbonWindowWithoutRibbon"
                                            Size="Middle"
                                            Click="OpenRibbonWindowWithoutRibbon_OnClick">Open Ribbon-Window without Ribbon</Fluent:Button>
-                            <Fluent:Button x:Name="OpenModalRibbonWindow"
+                                <Fluent:Button x:Name="OpenModalRibbonWindow"
                                            Size="Middle"
                                            Click="OpenModalRibbonWindow_OnClick">Open Ribbon-Window (ShowDialog)</Fluent:Button>
-                            <Fluent:Button x:Name="OpenRibbonWindowOnNewThread"
+                                <Fluent:Button x:Name="OpenRibbonWindowOnNewThread"
                                            Size="Middle"
                                            Click="OpenRibbonWindowOnNewThread_OnClick">Open Ribbon-Window (new Thread)</Fluent:Button>
-                            <Fluent:Button x:Name="OpenRibbonWindowColorized"
+                                <Fluent:Button x:Name="OpenRibbonWindowColorized"
                                            Size="Middle"
                                            Click="OpenRibbonWindowColorized_OnClick">Open Ribbon-Window (colorized)</Fluent:Button>
-                            <Fluent:Button x:Name="OpenRibbonWindowWithBackgroundImage"
+                                <Fluent:Button x:Name="OpenRibbonWindowWithBackgroundImage"
                                            Size="Middle"
                                            Click="OpenRibbonWindowWithBackgroundImage_OnClick">Open Ribbon-Window (with background image)</Fluent:Button>
-                        </WrapPanel>
-                    </GroupBox>
-                    <GroupBox Header="Issue repros">
-                        <WrapPanel>
-                            <Fluent:Button x:Name="SleepButton"
+                            </WrapPanel>
+                        </GroupBox>
+                        <GroupBox Header="Issue repros">
+                            <WrapPanel>
+                                <Fluent:Button x:Name="SleepButton"
                                            Size="Middle"
                                            VerticalAlignment="Top"
                                            Click="SleepButton_OnClick">Sleep for issues #80 and #159</Fluent:Button>
-                            
-                            <Fluent:Button Size="Middle"
+
+                                <Fluent:Button Size="Middle"
                                            VerticalAlignment="Top"
                                            ToolTip="Theme should change every 2 seconds."
-                                           Command="{Binding IssueReprosViewModel.ThemeManagerFromThread.StartStopCommand}">Change theme from thread</Fluent:Button>                            
-                            
-                            <GroupBox Header="KeyTip issues #254">
-                                <StackPanel Orientation="Vertical">
-                                    <formsInterop:WindowsFormsHost>
-                                        <forms:TextBox Height="30"
-                                                       Text="Test Windows.Forms.TextBox" />
-                                    </formsInterop:WindowsFormsHost>
+                                           Command="{Binding IssueReprosViewModel.ThemeManagerFromThread.StartStopCommand}">Change theme from thread</Fluent:Button>
 
-                                    <StackPanel>
-                                        <Label Target="{Binding ElementName=targetTextBox}">Label with _Access Key A</Label>
-                                        <TextBox x:Name="targetTextBox">Test System.Windows.Controls.TextBox</TextBox>
+                                <GroupBox Header="KeyTip issues #254">
+                                    <StackPanel Orientation="Vertical">
+                                        <formsInterop:WindowsFormsHost>
+                                            <forms:TextBox Height="30"
+                                                       Text="Test Windows.Forms.TextBox" />
+                                        </formsInterop:WindowsFormsHost>
+
+                                        <StackPanel>
+                                            <Label Target="{Binding ElementName=targetTextBox}">Label with _Access Key A</Label>
+                                            <TextBox x:Name="targetTextBox">Test System.Windows.Controls.TextBox</TextBox>
+                                        </StackPanel>
                                     </StackPanel>
-                                </StackPanel>
-                            </GroupBox>
-                        </WrapPanel>
-                    </GroupBox>
-                </StackPanel>
+                                </GroupBox>
+                            </WrapPanel>
+                        </GroupBox>
+                    </StackPanel>
                 </ScrollViewer>
             </TabItem>
 
@@ -3439,7 +3441,7 @@ Pellentesque nec dolor sed lacus tristique rutrum sed vitae urna. Sed eu pharetr
                         <Button x:Name="CreateThemeResourceDictionaryButton"
                                 Click="CreateThemeResourceDictionaryButton_OnClick">Create theme</Button>
                     </StackPanel>
-                    
+
                     <TextBox x:Name="ThemeResourceDictionaryTextBox" 
                              Grid.Row="1"
                              IsReadOnly="True"
@@ -3471,15 +3473,15 @@ Pellentesque nec dolor sed lacus tristique rutrum sed vitae urna. Sed eu pharetr
                                   HorizontalAlignment="Left">
                 <TextBlock Text="150 px" />
             </Fluent:StatusBarItem>
-            
+
             <Separator HorizontalAlignment="Left" />
-            
+
             <Fluent:StatusBarItem Title="Selected Words"
                                   Value="15"
                                   ToolTip="This is Selected Words"
                                   Content="15 words"
                                   HorizontalAlignment="Left" />
-            
+
             <Separator HorizontalAlignment="Left" />
 
             <Fluent:StatusBarItem Title="Used memory"

--- a/Fluent.Ribbon.Showcase/TestContent.xaml
+++ b/Fluent.Ribbon.Showcase/TestContent.xaml
@@ -435,10 +435,10 @@ Pellentesque nec dolor sed lacus tristique rutrum sed vitae urna. Sed eu pharetr
             <Fluent:RibbonTabItem Header="Toolbars"
                                   KeyTip="TO"
                                   ReduceOrder="Clipboard,Clipboard,Group, Group, Group, Font, Font, Font, Font,B,A,A,A,(A),(A),(A),Clipboard,Font,B,B,(A),C,(A),(A)">
-                <Fluent:RibbonGroupBox Icon="{DynamicResource Fluent.Ribbon.Images.DefaultPlaceholder}"
-                                       KeyTip="C"
-                                       x:Name="Clipboard"
+                <Fluent:RibbonGroupBox x:Name="Clipboard"
                                        Header="Clipboard"
+                                       KeyTip="C"
+                                       Icon="{DynamicResource Fluent.Ribbon.Images.DefaultPlaceholder}"
                                        IsLauncherVisible="True"
                                        LauncherClick="OnLauncherButtonClick"
                                        LauncherKeys="ZB">
@@ -741,15 +741,15 @@ Pellentesque nec dolor sed lacus tristique rutrum sed vitae urna. Sed eu pharetr
                     </Fluent:DropDownButton>
                 </Fluent:RibbonGroupBox>
 
-                <Fluent:RibbonGroupBox KeyTip="F"
-                                       x:Name="Font"
+                <Fluent:RibbonGroupBox x:Name="Font"
                                        Header="Font"
                                        StateDefinition="Large,Middle,Small"
+                                       KeyTip="F"
+                                       Icon="pack://application:,,,/Fluent.Ribbon.Showcase;component/Images/FontColor.png"
                                        IsLauncherVisible="True"
                                        LauncherClick="OnLauncherButtonClick"
-                                       Icon="pack://application:,,,/Fluent.Ribbon.Showcase;component/Images/FontColor.png"
-                                       LauncherIcon="/Images/FontColor.png"
-                                       LauncherKeys="NF">
+                                       LauncherKeys="NF"
+                                       LauncherIcon="/Images/FontColor.png">
                     <Fluent:RibbonToolBar>
                         <!--ToolBar Layout Definitions-->
                         <Fluent:RibbonToolBar.LayoutDefinitions>

--- a/Fluent.Ribbon/Controls/RibbonGroupBox.cs
+++ b/Fluent.Ribbon/Controls/RibbonGroupBox.cs
@@ -113,6 +113,31 @@ namespace Fluent
         /// <inheritdoc />
         public bool IsContextMenuOpened { get; set; }
 
+        #region StateDefinition
+
+        /// <summary>
+        /// Gets or sets whether ribbon control click must close backstage
+        /// </summary>
+        public RibbonGroupBoxStateDefinition StateDefinition
+        {
+            get { return (RibbonGroupBoxStateDefinition)this.GetValue(StateDefinitionProperty); }
+            set { this.SetValue(StateDefinitionProperty, value); }
+        }
+
+        /// <summary>Identifies the <see cref="StateDefinition"/> dependency property.</summary>
+        public static readonly DependencyProperty StateDefinitionProperty =
+            DependencyProperty.Register(nameof(StateDefinition), typeof(RibbonGroupBoxStateDefinition), typeof(RibbonGroupBox),
+                new PropertyMetadata(new RibbonGroupBoxStateDefinition(null), OnStateDefinitionChanged));
+
+        // Handles StateDefinitionProperty changes
+        internal static void OnStateDefinitionChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            var box = (RibbonGroupBox)d;
+            box.TryClearCacheAndResetStateAndScaleAndNotifyParentRibbonGroupsContainer();
+        }
+
+        #endregion
+
         #region State
 
         /// <summary>

--- a/Fluent.Ribbon/Controls/RibbonGroupsContainer.cs
+++ b/Fluent.Ribbon/Controls/RibbonGroupsContainer.cs
@@ -214,9 +214,7 @@ namespace Fluent
             }
             else
             {
-                groupBox.StateIntermediate = groupBox.StateIntermediate != RibbonGroupBoxState.Large
-                    ? groupBox.StateIntermediate - 1
-                    : RibbonGroupBoxState.Large;
+                groupBox.StateIntermediate = groupBox.StateDefinition.EnlargeState(groupBox.StateIntermediate);
             }
         }
 
@@ -237,9 +235,7 @@ namespace Fluent
             }
             else
             {
-                groupBox.StateIntermediate = groupBox.StateIntermediate != RibbonGroupBoxState.Collapsed
-                    ? groupBox.StateIntermediate + 1
-                    : groupBox.StateIntermediate;
+                groupBox.StateIntermediate = groupBox.StateDefinition.ReduceState(groupBox.StateIntermediate);
             }
         }
 

--- a/Fluent.Ribbon/Controls/RibbonToolBar.cs
+++ b/Fluent.Ribbon/Controls/RibbonToolBar.cs
@@ -196,16 +196,33 @@ namespace Fluent
                 return this.LayoutDefinitions[0];
             }
 
+            var size = this.Size;
+            var map = new Dictionary<RibbonControlSize, RibbonToolBarLayoutDefinition>();
             foreach (var definition in this.LayoutDefinitions)
             {
-                if (RibbonProperties.GetSize(definition) == RibbonProperties.GetSize(this))
+                var definitionSize = definition.Size;
+                if (definitionSize == size)
                 {
                     return definition;
                 }
+
+                map[definitionSize] = definition;
             }
 
-            // TODO: try to find a better definition
-            return this.LayoutDefinitions[0];
+            // find the closest definition if no matching definition exists
+            switch (size)
+            {
+                case RibbonControlSize.Large:
+                    return map.ContainsKey(RibbonControlSize.Middle) ? map[RibbonControlSize.Middle] : (map.ContainsKey(RibbonControlSize.Small) ? map[RibbonControlSize.Small] : this.LayoutDefinitions[0]);
+
+                case RibbonControlSize.Middle:
+                    return map.ContainsKey(RibbonControlSize.Small) ? map[RibbonControlSize.Small] : (map.ContainsKey(RibbonControlSize.Large) ? map[RibbonControlSize.Large] : this.LayoutDefinitions[0]);
+
+                case RibbonControlSize.Small:
+                    return map.ContainsKey(RibbonControlSize.Middle) ? map[RibbonControlSize.Middle] : (map.ContainsKey(RibbonControlSize.Large) ? map[RibbonControlSize.Large] : this.LayoutDefinitions[0]);
+                default:
+                    return this.LayoutDefinitions[0];
+            }
         }
 
         #endregion

--- a/Fluent.Ribbon/Converters/StateDefinitionConverter.cs
+++ b/Fluent.Ribbon/Converters/StateDefinitionConverter.cs
@@ -1,0 +1,24 @@
+﻿namespace Fluent.Converters
+{
+    using System;
+    using System.ComponentModel;
+    using System.Globalization;
+
+    /// <summary>
+    /// Class which enables conversion from <see cref="string"/> to <see cref="RibbonGroupBoxStateDefinition"/>
+    /// </summary>
+    public class StateDefinitionConverter : TypeConverter
+    {
+        /// <inheritdoc />
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType.IsAssignableFrom(typeof(string));
+        }
+
+        /// <inheritdoc />
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            return new RibbonGroupBoxStateDefinition(value as string);
+        }
+    }
+}

--- a/Fluent.Ribbon/Data/RibbonGroupBoxStateDefinition.cs
+++ b/Fluent.Ribbon/Data/RibbonGroupBoxStateDefinition.cs
@@ -1,0 +1,227 @@
+﻿// ReSharper disable once CheckNamespace
+namespace Fluent
+{
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Fluent.Converters;
+
+    /// <summary>
+    /// This class holds the Holds transitionable states when the <see cref="RibbonGroupsContainer"/> automatically resizes the <see cref="RibbonGroupBox"/>.
+    /// </summary>
+    [TypeConverter(typeof(StateDefinitionConverter))]
+    public struct RibbonGroupBoxStateDefinition : IEquatable<RibbonGroupBoxStateDefinition>
+    {
+        private const int MaxStateDefinitionParts = 4;
+
+        /// <summary>
+        /// Creates a new instance
+        /// </summary>
+        public RibbonGroupBoxStateDefinition(string? stateDefinition)
+            : this()
+        {
+            this.states = new List<RibbonGroupBoxState>
+                {
+                    RibbonGroupBoxState.Large,
+                    RibbonGroupBoxState.Middle,
+                    RibbonGroupBoxState.Small,
+                    RibbonGroupBoxState.Collapsed,
+                };
+
+            if (string.IsNullOrEmpty(stateDefinition))
+            {
+                return;
+            }
+
+            var splitted = stateDefinition!.Split(new[] { ' ', ',', ';', '-', '>' }, MaxStateDefinitionParts, StringSplitOptions.RemoveEmptyEntries).ToList();
+
+            if (splitted.Count == 0)
+            {
+                return;
+            }
+
+            var states = new List<RibbonGroupBoxState>();
+            foreach (var item in splitted)
+            {
+                var state = ToRibbonGroupBoxState(item);
+                if (!states.Contains(state))
+                {
+                    if (state != RibbonGroupBoxState.QuickAccess)
+                    {
+                        states.Add(state);
+                    }
+                }
+
+                if (states.Count >= MaxStateDefinitionParts)
+                {
+                    break;
+                }
+            }
+
+            if (states.Count > 0)
+            {
+                states.Sort();  // sort large to small
+                this.states = states;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the transitionable states
+        /// </summary>
+        /// 
+        public IReadOnlyList<RibbonGroupBoxState> States
+        {
+            get { return this.states; }
+        }
+
+        private readonly List<RibbonGroupBoxState> states;
+
+        /// <summary>
+        /// Converts from <see cref="string"/> to <see cref="RibbonGroupBoxStateDefinition"/>
+        /// </summary>
+        public static RibbonGroupBoxStateDefinition FromString(string stateDefinition)
+        {
+            return new RibbonGroupBoxStateDefinition(stateDefinition);
+        }
+
+        /// <summary>
+        /// Converts from <see cref="string"/> to <see cref="RibbonGroupBoxStateDefinition"/>
+        /// </summary>
+        public static implicit operator RibbonGroupBoxStateDefinition(string stateDefinition)
+        {
+            return FromString(stateDefinition);
+        }
+
+        /// <summary>
+        /// Converts from <see cref="RibbonGroupBoxStateDefinition"/> to <see cref="string"/>
+        /// </summary>
+        public static implicit operator string(RibbonGroupBoxStateDefinition stateDefinition)
+        {
+            return stateDefinition.ToString();
+        }
+
+        /// <summary>
+        /// Converts from <see cref="string"/> to <see cref="RibbonGroupBoxState"/>
+        /// </summary>
+        public static RibbonGroupBoxState ToRibbonGroupBoxState(string ribbonControlState)
+        {
+            return Enum.TryParse(ribbonControlState, true, out RibbonGroupBoxState result)
+                       ? result
+                       : RibbonGroupBoxState.Large;
+        }
+
+        /// <summary>
+        /// Gets the appropriate enlarged <see cref="RibbonGroupBoxState"/> depending on StateDefinition />
+        /// </summary>
+        public RibbonGroupBoxState EnlargeState(RibbonGroupBoxState ribbonGroupBoxState)
+        {
+            var index = this.states.IndexOf(ribbonGroupBoxState);
+            if (index > 0 && index < this.states.Count)
+            {
+                return this.states[index - 1];
+            }
+            else
+            {
+                return this.states.First();
+            }
+        }
+
+        /// <summary>
+        /// Gets the appropriate reduced <see cref="RibbonGroupBoxState"/> depending on StateDefinition />
+        /// </summary>
+        public RibbonGroupBoxState ReduceState(RibbonGroupBoxState ribbonGroupBoxState)
+        {
+            var index = this.states.IndexOf(ribbonGroupBoxState);
+            if (index >= 0 && index < this.states.Count - 1)
+            {
+                return this.states[index + 1];
+            }
+            else
+            {
+                return this.states.Last();
+            }
+        }
+
+        #region Overrides of ValueType
+
+        /// <inheritdoc />
+        public override bool Equals(object? obj)
+        {
+            if (obj is null)
+            {
+                return false;
+            }
+
+            return obj is RibbonGroupBoxStateDefinition definition
+                   && this.Equals(definition);
+        }
+
+        #region Equality members
+
+        /// <inheritdoc />
+        public bool Equals(RibbonGroupBoxStateDefinition other)
+        {
+            if (this.states.Count != other.states.Count)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < this.states.Count; i++)
+            {
+                if (this.states[i] != other.states[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = (int)this.states.Count;
+                this.states.ForEach(i => hashCode = (hashCode * 397) ^ (int)i);
+                return hashCode;
+            }
+        }
+
+        /// <summary>Determines whether the specified object instances are considered equal.</summary>
+        /// <param name="left">The first object to compare. </param>
+        /// <param name="right">The second object to compare. </param>
+        /// <returns>true if the objects are considered equal; otherwise, false. If both <paramref name="left" /> and <paramref name="right" /> are null, the method returns true.</returns>
+        public static bool operator ==(RibbonGroupBoxStateDefinition left, RibbonGroupBoxStateDefinition right)
+        {
+            return left.Equals(right);
+        }
+
+        /// <summary>Determines whether the specified object instances are not considered equal.</summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns>true if the objects are not considered equal; otherwise, false. If both <paramref name="left" /> and <paramref name="right" /> are null, the method returns false.</returns>
+        public static bool operator !=(RibbonGroupBoxStateDefinition left, RibbonGroupBoxStateDefinition right)
+        {
+            return !left.Equals(right);
+        }
+
+        #endregion
+
+        #endregion
+
+        /// <summary>
+        /// Returns a string that represents the current object.
+        /// </summary>
+        /// <returns>
+        /// A string that represents the current object.
+        /// </returns>
+        public override string ToString()
+        {
+            return string.Join(",", this.states);
+        }
+    }
+}

--- a/Fluent.Ribbon/Data/RibbonGroupBoxStateDefinition.cs
+++ b/Fluent.Ribbon/Data/RibbonGroupBoxStateDefinition.cs
@@ -119,12 +119,29 @@ namespace Fluent
         public RibbonGroupBoxState EnlargeState(RibbonGroupBoxState ribbonGroupBoxState)
         {
             var index = this.states.IndexOf(ribbonGroupBoxState);
-            if (index > 0 && index < this.states.Count)
+            if (index >= 0)
             {
-                return this.states[index - 1];
+                if (index > 0)
+                {
+                    return this.states[index - 1];
+                }
+                else
+                {
+                    return this.states.First();
+                }
             }
             else
             {
+                //  If not found current state, find the closest state that exists in the state list
+                while (--ribbonGroupBoxState >= RibbonGroupBoxState.Large)
+                {
+                    index = this.states.IndexOf(ribbonGroupBoxState);
+                    if (index >= 0)
+                    {
+                        return this.states[index];
+                    }
+                }
+
                 return this.states.First();
             }
         }
@@ -135,12 +152,29 @@ namespace Fluent
         public RibbonGroupBoxState ReduceState(RibbonGroupBoxState ribbonGroupBoxState)
         {
             var index = this.states.IndexOf(ribbonGroupBoxState);
-            if (index >= 0 && index < this.states.Count - 1)
+            if (index >= 0)
             {
-                return this.states[index + 1];
+                if (index < this.states.Count - 1)
+                {
+                    return this.states[index + 1];
+                }
+                else
+                {
+                    return this.states.Last();
+                }
             }
             else
             {
+                // If not found current state, find the closest state that exists in the state list
+                while (++ribbonGroupBoxState <= RibbonGroupBoxState.Collapsed)
+                {
+                    index = this.states.IndexOf(ribbonGroupBoxState);
+                    if (index >= 0)
+                    {
+                        return this.states[index];
+                    }
+                }
+
                 return this.states.Last();
             }
         }


### PR DESCRIPTION
This Implement resolves #931 (support StateDefinition property of RibbonGroupBox)

You can check the behavior in the Font RibbonGroupBox of the Fluent.Ribbon.Showcase app.
When changing windows size, the Font RibbonGroupBox does not transition to the Collapsed state because the StateDefinition property is set to "Large, Middle, Small".

```
<Fluent:RibbonTabItem Header="Toolbars"
                      KeyTip="TO"
                      ReduceOrder="Clipboard,Clipboard,Group, Group, Group, Font, Font, Font, Font,B,A,A,A,(A),(A),(A),Clipboard,Font,B,B,(A),C,(A),(A)">
    ...
    <Fluent:RibbonGroupBox KeyTip="F"
                           x:Name="Font"
                           Header="Font"
                           StateDefinition="Large,Middle,Small"
                           IsLauncherVisible="True"
                           ...
```