### PR TITLE
fix: icon size of Button control is always small

### DIFF
--- a/Fluent.Ribbon/Themes/Controls/Button.xaml
+++ b/Fluent.Ribbon/Themes/Controls/Button.xaml
@@ -84,6 +84,7 @@
                         Orientation="Vertical">
                 <Fluent:IconPresenter x:Name="iconImage"
                                       Margin="0 2 0 0"
+                                      IconSize="{Binding (Fluent:RibbonProperties.IconSize), RelativeSource={RelativeSource TemplatedParent}}"
                                       SmallIcon="{Binding Icon, RelativeSource={RelativeSource TemplatedParent}}"
                                       LargeIcon="{Binding LargeIcon, RelativeSource={RelativeSource TemplatedParent}}" />
 


### PR DESCRIPTION
As this is a fix for the develop branch, which is not released as a package, I have not created an issue ticket for this problem.