### PR TITLE
Feature: add frame feature to icon presenter

### DIFF
--- a/Fluent.Ribbon.Showcase/TestContent.xaml
+++ b/Fluent.Ribbon.Showcase/TestContent.xaml
@@ -2363,7 +2363,7 @@ Pellentesque nec dolor sed lacus tristique rutrum sed vitae urna. Sed eu pharetr
 
             <Fluent:RibbonTabItem Header="Resizing &amp; Screentips"
                                   KeyTip="RS"
-                                  ReduceOrder="Default,Default,Default,Large,Large,Large,Other,Other,Other">
+                                  ReduceOrder="Default,Default,Default,Large,Large,Large,Other,Other,Other,Icon,Icon,Icon">
 
                 <!--All group can be in four state: Large->Middle->Small->Collapsed
                     By default group in Large state. When group changes its state it 
@@ -2469,6 +2469,22 @@ Pellentesque nec dolor sed lacus tristique rutrum sed vitae urna. Sed eu pharetr
                                    Header="Grey"
                                    Icon="pack://application:,,,/Fluent.Ribbon.Showcase;component/Images/Brown.png"
                                    LargeIcon="pack://application:,,,/Fluent.Ribbon.Showcase;component/Images/BrownLarge.png" />
+                </Fluent:RibbonGroupBox>
+                
+                <Fluent:RibbonGroupBox Name="Icon"
+                                       Header="Icon">
+                    <Fluent:Button Header="Small icon only"
+                                   Icon="pack://application:,,,/Fluent.Ribbon.Showcase;component/Images/Green.png"/>
+                    <Fluent:Button Header="Large icon only"
+                                   LargeIcon="pack://application:,,,/Fluent.Ribbon.Showcase;component/Images/GrayLarge.png"/>
+                    <Fluent:Button Header="Both icon"
+                                   Icon="pack://application:,,,/Fluent.Ribbon.Showcase;component/Images/Yellow.png"
+                                   LargeIcon="pack://application:,,,/Fluent.Ribbon.Showcase;component/Images/YellowLarge.png"/>
+                    <Fluent:Button Header="Both icon"
+                                   Icon="pack://application:,,,/Fluent.Ribbon.Showcase;component/Images/Brown.png"
+                                   LargeIcon="pack://application:,,,/Fluent.Ribbon.Showcase;component/Images/BrownLarge.png"/>
+                    <Fluent:Button Header="No icon"/>
+                    <Fluent:Button/> <!-- no icon, no header text-->
                 </Fluent:RibbonGroupBox>
             </Fluent:RibbonTabItem>
 

--- a/Fluent.Ribbon/Controls/IconPresenter.cs
+++ b/Fluent.Ribbon/Controls/IconPresenter.cs
@@ -5,6 +5,7 @@ namespace Fluent
     using System.Windows;
     using System.Windows.Controls;
     using System.Windows.Data;
+    using System.Windows.Media;
     using Fluent.Converters;
     using Fluent.Internal;
     using Fluent.Internal.KnownBoxes;
@@ -43,6 +44,14 @@ namespace Fluent
         public static readonly DependencyProperty LargeIconProperty = DependencyProperty.Register(
             nameof(LargeIcon), typeof(object), typeof(IconPresenter), new PropertyMetadata(default, PropertyChangedCallback));
 
+        /// <summary>Identifies the <see cref="BorderThickness"/> dependency property.</summary>
+        public static readonly DependencyProperty BorderThicknessProperty = DependencyProperty.Register(
+            nameof(BorderThickness), typeof(Thickness), typeof(IconPresenter), new PropertyMetadata(default(Thickness), PropertyChangedCallback));
+
+        /// <summary>Identifies the <see cref="BorderBrush"/> dependency property.</summary>
+        public static readonly DependencyProperty BorderBrushProperty = DependencyProperty.Register(
+            nameof(BorderBrush), typeof(Brush), typeof(IconPresenter), new PropertyMetadata(default(Brush), PropertyChangedCallback));
+
         /// <summary>Identifies the <see cref="OptimalIcon"/> dependency property.</summary>
         public static readonly DependencyProperty OptimalIconProperty = DependencyProperty.Register(
             nameof(OptimalIcon), typeof(object), typeof(IconPresenter), new PropertyMetadata(default));
@@ -61,7 +70,14 @@ namespace Fluent
         {
             grayscaleEffect ??= new();
 
-            var binding = new Binding(nameof(this.OptimalIcon))
+            var grid = new Grid();
+            var icon = new ContentPresenter();
+            var border = new Border();
+
+            grid.Children.Add(icon);
+            grid.Children.Add(border);
+
+            var iconBinding = new Binding(nameof(this.OptimalIcon))
             {
                 Source = this,
                 Converter = new ObjectToImageConverter
@@ -70,7 +86,21 @@ namespace Fluent
                     TargetVisualBinding = new Binding { Source = this }
                 }
             };
-            this.SetBinding(ContentProperty, binding);
+            icon.SetBinding(ContentProperty, iconBinding);
+
+            var borderBrushBinding = new Binding(nameof(this.BorderBrush))
+            {
+                Source = this
+            };
+            border.SetBinding(Border.BorderBrushProperty, borderBrushBinding);
+
+            var borderThicknessBinding = new Binding(nameof(this.BorderThickness))
+            {
+                Source = this
+            };
+            border.SetBinding(Border.BorderThicknessProperty, borderThicknessBinding);
+
+            this.Content = grid;
 
             this.UpdateSize();
         }
@@ -121,6 +151,18 @@ namespace Fluent
         {
             get => this.GetValue(LargeIconProperty);
             set => this.SetValue(LargeIconProperty, value);
+        }
+
+        public Thickness BorderThickness
+        {
+            get => (Thickness)this.GetValue(BorderThicknessProperty);
+            set => this.SetValue(BorderThicknessProperty, value);
+        }
+
+        public Brush? BorderBrush
+        {
+            get => (Brush)this.GetValue(BorderBrushProperty);
+            set => this.SetValue(BorderBrushProperty, value);
         }
 
         public object? OptimalIcon

--- a/Fluent.Ribbon/Themes/Controls/Button.xaml
+++ b/Fluent.Ribbon/Themes/Controls/Button.xaml
@@ -89,13 +89,62 @@
                                       LargeIcon="{Binding LargeIcon, RelativeSource={RelativeSource TemplatedParent}}" />
 
                 <Fluent:TwoLineLabel x:Name="controlLabel"
-                                     Text="{TemplateBinding Header}"
+                                     Margin="2 0 2 0" 
                                      HorizontalAlignment="Stretch"
                                      VerticalAlignment="Center"
-                                     Margin="2 0 2 0" />
+                                     Text="{TemplateBinding Header}" />
             </StackPanel>
         </Border>
         <ControlTemplate.Triggers>
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition Property="Size"
+                               Value="Small"/>
+                    <Condition Property="OptimalIcon"
+                               SourceName="iconImage"
+                               Value="{x:Null}"/>
+                </MultiTrigger.Conditions>                
+                <Setter Property="BorderThickness"
+                        TargetName="iconImage"
+                        Value="1" />
+                <Setter Property="BorderBrush"
+                        TargetName="iconImage"
+                        Value="{DynamicResource Fluent.Ribbon.Brushes.Control.BorderBrush}" />
+            </MultiTrigger>
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition Property="Size"
+                               Value="Middle"/>
+                    <Condition Property="OptimalIcon"
+                               SourceName="iconImage"
+                               Value="{x:Null}"/>
+                </MultiTrigger.Conditions>
+                <Setter Property="Visibility"
+                        TargetName="iconImage"
+                        Value="Collapsed" />
+            </MultiTrigger>
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition Property="Size"
+                               Value="Middle"/>
+                    <Condition Property="OptimalIcon"
+                               SourceName="iconImage"
+                               Value="{x:Null}"/>
+                    <Condition Property="Text"
+                               SourceName="controlLabel"
+                               Value="{x:Null}"/>
+                </MultiTrigger.Conditions>
+                <Setter Property="Visibility"
+                        TargetName="iconImage"
+                        Value="Visible" />
+                <Setter Property="BorderThickness"
+                        TargetName="iconImage"
+                        Value="1" />
+                <Setter Property="BorderBrush"
+                        TargetName="iconImage"
+                        Value="{DynamicResource Fluent.Ribbon.Brushes.Control.BorderBrush}" />
+            </MultiTrigger>
+
             <Trigger Property="Size"
                      Value="Small">
                 <Setter Property="Orientation"
@@ -109,9 +158,6 @@
                         Value="False" />
                 <Setter Property="Margin"
                         TargetName="iconImage"
-                        Value="2,0,2,0" />
-                <Setter Property="Margin"
-                        TargetName="controlLabel"
                         Value="2,0,2,0" />
             </Trigger>
             <Trigger Property="Size"
@@ -128,9 +174,6 @@
                 <Setter Property="HasTwoLines"
                         TargetName="controlLabel"
                         Value="False" />
-                <Setter Property="Margin"
-                        TargetName="controlLabel"
-                        Value="2,0,2,0" />
                 <Setter Property="VerticalAlignment"
                         TargetName="border"
                         Value="Stretch" />

--- a/Fluent.Ribbon/Themes/Controls/Button.xaml
+++ b/Fluent.Ribbon/Themes/Controls/Button.xaml
@@ -84,6 +84,7 @@
                         Orientation="Vertical">
                 <Fluent:IconPresenter x:Name="iconImage"
                                       Margin="0 2 0 0"
+                                      IconSize="{Binding (Fluent:RibbonProperties.IconSize), RelativeSource={RelativeSource TemplatedParent}}"
                                       SmallIcon="{Binding Icon, RelativeSource={RelativeSource TemplatedParent}}"
                                       LargeIcon="{Binding LargeIcon, RelativeSource={RelativeSource TemplatedParent}}" />
 


### PR DESCRIPTION
@batzen, I really like the IconPresenter control.
Thank you.

I've added the ability to display frames to this control.
It is used to display a frame when the icon property is null.

I have added a use case to the Button style.
I have added the behavior example as Icon group in the "Resizing & Screentips" tab of Fluent.Ribbon.Showcase.

 ```
...
        <Fluent:IconPresenter x:Name="iconImage"
                                Margin="0 2 0 0"
                                IconSize="{Binding (Fluent:RibbonProperties.IconSize), RelativeSource={RelativeSource TemplatedParent}}"
                                SmallIcon="{Binding Icon, RelativeSource={RelativeSource TemplatedParent}}"
                                LargeIcon="{Binding LargeIcon, RelativeSource={RelativeSource TemplatedParent}}" />

        <Fluent:TwoLineLabel x:Name="controlLabel"
                                Margin="2 0 2 0" 
                                HorizontalAlignment="Stretch"
                                VerticalAlignment="Center"
                                Text="{TemplateBinding Header}" />
    </StackPanel>
</Border>
<ControlTemplate.Triggers>
    <MultiTrigger>
        <MultiTrigger.Conditions>
            <Condition Property="Size"
                        Value="Small"/>
            <Condition Property="OptimalIcon"
                        SourceName="iconImage"
                        Value="{x:Null}"/>
        </MultiTrigger.Conditions>                
        <Setter Property="BorderThickness"
                TargetName="iconImage"
                Value="1" />
        <Setter Property="BorderBrush"
                TargetName="iconImage"
                Value="{DynamicResource Fluent.Ribbon.Brushes.Control.BorderBrush}" />
    </MultiTrigger>
```