### PR TITLE
fix for #941 (LauncherIcon of RibbonGroupBox is not applied)

### DIFF
--- a/Fluent.Ribbon.Showcase/TestContent.xaml
+++ b/Fluent.Ribbon.Showcase/TestContent.xaml
@@ -2721,10 +2721,11 @@ Pellentesque nec dolor sed lacus tristique rutrum sed vitae urna. Sed eu pharetr
                                   KeyTip="P">
                 <Fluent:RibbonGroupBox x:Name="PanelGroup11"
                                        Header="In RibbonToolBar"
-                                       LauncherText="launcher"
                                        Icon="pack://application:,,,/Fluent.Ribbon.Showcase;component/Images/Green.png"
                                        IsSeparatorVisible="True"
-                                       IsLauncherVisible="True">
+                                       IsLauncherVisible="True"
+                                       LauncherIcon="pack://application:,,,/Fluent.Ribbon.Showcase;component/Images/Green.png"
+                                       LauncherText="Launcher">
 
                     <Fluent:RibbonToolBar>
                         <Fluent:Button Header="Full(L/L/S) button"
@@ -2747,7 +2748,9 @@ Pellentesque nec dolor sed lacus tristique rutrum sed vitae urna. Sed eu pharetr
 
                 <Fluent:RibbonGroupBox x:Name="PanelGroup12"
                                        Header="In StackPanel"
-                                       Icon="pack://application:,,,/Fluent.Ribbon.Showcase;component/Images/Green.png">
+                                       Icon="pack://application:,,,/Fluent.Ribbon.Showcase;component/Images/Green.png"
+                                       IsLauncherVisible="True"
+                                       LauncherText="Launcher">
                     <StackPanel Orientation="Horizontal">
                         <Fluent:Button Header="Full(L/L/S) button"
                                        Icon="pack://application:,,,/Fluent.Ribbon.Showcase;component/Images/Gray.png"

--- a/Fluent.Ribbon/Themes/Controls/RibbonGroupBox.xaml
+++ b/Fluent.Ribbon/Themes/Controls/RibbonGroupBox.xaml
@@ -159,18 +159,18 @@
                                                 Margin="2,0"
                                                 KeyboardNavigation.IsTabStop="False" />
 
-                                <Fluent:Button Margin="0,0,1,1"
-                                               x:Name="PART_DialogLauncherButton"
-                                               HorizontalAlignment="Stretch"
+                                <Fluent:Button x:Name="PART_DialogLauncherButton"
+                                               Grid.Column="1"
                                                Width="15"
                                                Height="14"
-                                               Grid.Column="1"
+                                               Margin="0,0,1,1"
+                                               HorizontalAlignment="Stretch"
+                                               VerticalAlignment="Bottom"
+                                               Background="Transparent"
+                                               BorderBrush="Transparent"
                                                Focusable="False"
                                                IsTabStop="False"
                                                Template="{DynamicResource DialogLauncherButtonControlTemplate}"
-                                               Background="Transparent"
-                                               BorderBrush="Transparent"
-                                               VerticalAlignment="Bottom"
                                                Icon="{TemplateBinding LauncherIcon}"
                                                Header="{TemplateBinding LauncherText}"
                                                Command="{Binding LauncherCommand, RelativeSource={RelativeSource TemplatedParent}}"
@@ -208,6 +208,13 @@
                         TargetName="PART_ButtonBorder"
                         Value="{DynamicResource Fluent.Ribbon.Brushes.Button.MouseOver.BorderBrush}" />
             </MultiTrigger>
+            
+            <Trigger Property="LauncherToolTip"
+                     Value="{x:Null}">
+                <Setter Property="ToolTip"
+                        TargetName="PART_DialogLauncherButton"
+                        Value="{Binding LauncherText, RelativeSource={RelativeSource TemplatedParent}}" />
+            </Trigger>
         </ControlTemplate.Triggers>
     </ControlTemplate>
 
@@ -272,16 +279,16 @@
                                             Margin="2,0"
                                             KeyboardNavigation.IsTabStop="False" />
 
-                            <Fluent:Button Margin="0,0,1,1"
-                                           x:Name="PART_DialogLauncherButton"
-                                           HorizontalAlignment="Stretch"
+                            <Fluent:Button x:Name="PART_DialogLauncherButton"
+                                           Grid.Column="1"
                                            Width="15"
                                            Height="14"
-                                           Grid.Column="1"
-                                           Template="{DynamicResource DialogLauncherButtonControlTemplate}"
+                                           Margin="0,0,1,1"
+                                           HorizontalAlignment="Stretch"
+                                           VerticalAlignment="Bottom"
                                            Background="Transparent"
                                            BorderBrush="Transparent"
-                                           VerticalAlignment="Bottom"
+                                           Template="{DynamicResource DialogLauncherButtonControlTemplate}"
                                            Icon="{TemplateBinding LauncherIcon}"
                                            Header="{TemplateBinding LauncherText}"
                                            Command="{Binding LauncherCommand, RelativeSource={RelativeSource TemplatedParent}}"
@@ -397,11 +404,18 @@
                 <Setter Property="Background"
                         Value="{DynamicResource Fluent.Ribbon.Brushes.RibbonGroupBox.DropDownOpen.Background}" />
             </Trigger>
+            
             <Trigger Property="IsLauncherVisible"
                      Value="False">
                 <Setter Property="Visibility"
                         TargetName="PART_DialogLauncherButton"
                         Value="Collapsed" />
+            </Trigger>
+            <Trigger Property="LauncherToolTip"
+                     Value="{x:Null}">
+                <Setter Property="ToolTip"
+                        TargetName="PART_DialogLauncherButton"
+                        Value="{Binding LauncherText, RelativeSource={RelativeSource TemplatedParent}}" />
             </Trigger>
         </ControlTemplate.Triggers>
     </ControlTemplate>
@@ -412,21 +426,31 @@
                 BorderThickness="1"
                 Background="{TemplateBinding Background}"
                 BorderBrush="{TemplateBinding BorderBrush}">
-            <Image x:Name="image"
-                   Width="8"
-                   Height="8"
-                   HorizontalAlignment="Center"
-                   VerticalAlignment="Center"
-                   Stretch="Uniform"
-                   Source="{DynamicResource Fluent.Ribbon.Images.DialogLauncher}"
-                   SnapsToDevicePixels="True">
-            </Image>
+            <Fluent:IconPresenter x:Name="iconImage"
+                                  HorizontalAlignment="Center"
+                                  VerticalAlignment="Center"
+                                  IconSize="Custom"
+                                  CustomSize="8,8"
+                                  SmallIcon="{Binding Icon, RelativeSource={RelativeSource TemplatedParent}}"
+                                  LargeIcon="{Binding LargeIcon, RelativeSource={RelativeSource TemplatedParent}}" />
         </Border>
         <ControlTemplate.Triggers>
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition Property="Icon"
+                               Value="{x:Null}" />
+                    <Condition Property="LargeIcon"
+                               Value="{x:Null}" />
+                </MultiTrigger.Conditions>
+                <Setter Property="SmallIcon"
+                        TargetName="iconImage"
+                        Value="{DynamicResource Fluent.Ribbon.Images.DialogLauncher}" />
+            </MultiTrigger>
+
             <Trigger Property="FlowDirection"
                      Value="RightToLeft">
                 <Setter Property="RenderTransform"
-                        TargetName="image">
+                        TargetName="iconImage">
                     <Setter.Value>
                         <ScaleTransform ScaleX="-1" />
                     </Setter.Value>


### PR DESCRIPTION
fix #941

Set LauncherIcon to Icon of Launcher button when LauncherIcon is not null
Set LauncherText to Tooltip of Launcher button when LauncherToolTip is null

**Before:**
<img width="356" alt="LauncherIcon-Text-before" src="https://user-images.githubusercontent.com/13976757/119247520-2b0a9f80-bbc5-11eb-84cd-73993cf084f6.png">

**After:**
<img width="358" alt="LauncherIcon-Text-after" src="https://user-images.githubusercontent.com/13976757/119247521-2d6cf980-bbc5-11eb-8016-9a606cb417d1.png">

