### PR TITLE
fix for #943 (LauncherIcon in RibbonGroupBox on QuickAccess is always shown)

### DIFF
--- a/Fluent.Ribbon/Themes/Controls/RibbonGroupBox.xaml
+++ b/Fluent.Ribbon/Themes/Controls/RibbonGroupBox.xaml
@@ -208,7 +208,13 @@
                         TargetName="PART_ButtonBorder"
                         Value="{DynamicResource Fluent.Ribbon.Brushes.Button.MouseOver.BorderBrush}" />
             </MultiTrigger>
-            
+
+            <Trigger Property="IsLauncherVisible"
+                     Value="False">
+                <Setter Property="Visibility"
+                        TargetName="PART_DialogLauncherButton"
+                        Value="Collapsed" />
+            </Trigger>
             <Trigger Property="LauncherToolTip"
                      Value="{x:Null}">
                 <Setter Property="ToolTip"


### PR DESCRIPTION
fix #943 

Add the trigger of IsLauncherVisible to ControlTemplate.Triggers.

**Before:**
<img width="346" alt="LauncherIcon-in-QuickToolBar-before" src="https://user-images.githubusercontent.com/13976757/119353418-d3138c00-bcdd-11eb-8c0f-75e63cf4d9ac.png">

**After:**
<img width="334" alt="LauncherIcon-in-QuickToolBar-after" src="https://user-images.githubusercontent.com/13976757/119356298-3b17a180-bce1-11eb-9195-e854c23e0219.png">
