### PR TITLE
Detach from KeyDown event to match code in Show()

### DIFF
--- a/Fluent.Ribbon/Controls/Backstage.cs
+++ b/Fluent.Ribbon/Controls/Backstage.cs
@@ -610,7 +610,7 @@ namespace Fluent
 
             if (this.ownerWindow is not null)
             {
-                this.ownerWindow.PreviewKeyDown -= this.HandleOwnerWindowKeyDown;
+                this.ownerWindow.KeyDown -= this.HandleOwnerWindowKeyDown;
                 this.ownerWindow.SizeChanged -= this.HandleOwnerWindowSizeChanged;
 
                 if (double.IsNaN(this.savedWindowMinWidth) == false


### PR DESCRIPTION
As written, `Backstage` will attach to the `KeyDown` event of the owning window but later detach from the `PreviewKeyDown` event. This creates a memory leak where the `Backstage` instance (and everything else referenced from it) will be kept in memory for as long as the owning window, via the `KeyDown` event. In our application the appearance of the main window changes according to which mode the application is in, with the ribbon control part of the visual tree in only one of these modes. In this (perhaps slightly unusual) setup, simply opening the backstage will cause the application to leak memory. This PR aims to solve this problem by detaching from the `KeyDown` event in `RestoreParentProperties` as was, presumably, the original intent.