### PR TITLE
Fixes #1041 by making MenuItem create ToggleButton on QAT

### DIFF
--- a/Fluent.Ribbon.Showcase/TestContent.xaml
+++ b/Fluent.Ribbon.Showcase/TestContent.xaml
@@ -1914,6 +1914,7 @@
                         <Fluent:MenuItem Header="First (with icon)"
                                          GroupName="{Binding Converter={StaticResource UniqueGroupNameConverter}, ConverterParameter=MenuItemGroup1}"
                                          Icon="Images/Pink.png"
+                                         CanAddToQuickAccessToolBar="True"
                                          IsCheckable="True"
                                          IsChecked="True" />
                         <Fluent:MenuItem Header="Second"

--- a/Fluent.Ribbon/Controls/MenuItem.cs
+++ b/Fluent.Ribbon/Controls/MenuItem.cs
@@ -325,9 +325,19 @@ namespace Fluent
             }
             else
             {
-                var button = new Button();
-                RibbonControl.BindQuickAccessItem(this, button);
-                return button;
+                if (this.IsCheckable)
+                {
+                    var toggleButton = new ToggleButton();
+                    RibbonControl.Bind(this, toggleButton, nameof(this.IsChecked), System.Windows.Controls.Primitives.ToggleButton.IsCheckedProperty, BindingMode.TwoWay);
+                    RibbonControl.BindQuickAccessItem(this, toggleButton);
+                    return toggleButton;
+                }
+                else
+                {
+                    var button = new Button();
+                    RibbonControl.BindQuickAccessItem(this, button);
+                    return button;
+                }
             }
         }
 


### PR DESCRIPTION
MenuItem creates ToggleButton on QAT if IsCheckable=true, else the old behavior (regular button).
Added CanAddToQuickAccessToolbar=true to one existing menu item on the tests tab so this can be tested in the ShowCase app.

Fixes #1041 