### PR TITLE
DismissOnClickOutside property added to DropDownButton

### DIFF
--- a/Fluent.Ribbon/Controls/DropDownButton.cs
+++ b/Fluent.Ribbon/Controls/DropDownButton.cs
@@ -107,6 +107,25 @@ public class DropDownButton : ItemsControl, IQuickAccessItemProvider, IRibbonCon
     /// <inheritdoc />
     public bool IsContextMenuOpened { get; set; }
 
+    #region DismissOnClickOutside
+
+    /// <summary>
+    /// If false: popup will not be dismissed if a mouse click occurred outside the DropDownButon's borders. <para></para>
+    /// <see cref="IsDropDownOpen"/> and <see cref="ClosePopupOnMouseDown"/> will not be affected by this value.<para/>
+    /// Default value is True.
+    /// </summary>
+    public bool DismissOnClickOutside
+    {
+        get => (bool)this.GetValue(DismissOnClickOutsideProperty);
+        set => this.SetValue(DismissOnClickOutsideProperty, BooleanBoxes.Box(value));
+    }
+
+    /// <summary>Identifies the <see cref="DismissOnClickOutside"/> dependency property.</summary>
+    public static readonly DependencyProperty DismissOnClickOutsideProperty =
+        DependencyProperty.Register(nameof(DismissOnClickOutside), typeof(bool), typeof(DropDownButton), new PropertyMetadata(BooleanBoxes.TrueBox));
+
+    #endregion
+
     #region Header
 
     /// <inheritdoc />

--- a/Fluent.Ribbon/Services/PopupService.cs
+++ b/Fluent.Ribbon/Services/PopupService.cs
@@ -335,7 +335,8 @@ public static class PopupService
 
     private static void DismisPopupForMouseNotOver(IDropDownControl control, DismissPopupEventArgs e)
     {
-        if (control.IsDropDownOpen == false)
+        if (control.IsDropDownOpen == false ||
+            control is DropDownButton { DismissOnClickOutside: false })
         {
             return;
         }


### PR DESCRIPTION
Hi, I have been using `DropDownButton`s and `SplitButton`s to show dialogs by setting the content of these buttons equals to the dialog's content, this results in a pretty slide-down show behavior.. This is a sample snippet
```xaml
<fluent:DropDownButton
      Header="Header"
      IsDropDownOpen="{Binding IsDialogOpen, Mode=TwoWay}"
      SizeDefinition="Large, Large, Large">
      <fluent:DropDownButton.LargeIcon/>
      <views:MyDialog/>
</fluent:DropDownButton>
```
with this, I only miss one thing, prevent closing the drop-down-dialog when clicking outside, so, I have added a property named `DismissOnClickOutside` to DropDownButton class.. setting it to false will prevent closing the dialog unless the user clicks over the DropDownButton

**Notes**: 
1. This property does not affect other properties like `IsDropDownOpen` or `ClosePopupOnMouseDown`
2. I could not have just Inherit `DropDownButton` and make my own DropDownButton to achive my purpose because I needed to add a check code inside [PopupService.cs](https://github.com/fluentribbon/Fluent.Ribbon/blame/da0af2ee86978effa41acefc7de5654edb8354c7/Fluent.Ribbon/Services/PopupService.cs#L339)
3. The default value of `DismissOnClickOutside` is `true`, which leads to the normal behavior (i.e. closing the popup when clicking outside)