### PR TITLE
Add option to use legacy/office-style mouse wheel tab shifting

### DIFF
--- a/Fluent.Ribbon.Showcase/TestContent.xaml
+++ b/Fluent.Ribbon.Showcase/TestContent.xaml
@@ -3300,6 +3300,9 @@
                                         <Fluent:CheckBox IsChecked="{Binding IsMouseWheelScrollingEnabled, ElementName=ribbon}">
                                             IsMouseWheelScrollingEnabled
                                         </Fluent:CheckBox>
+                                        <Fluent:CheckBox IsChecked="{Binding IsMouseWheelScrollingEnabledEverywhere, ElementName=ribbon}">
+                                            IsMouseWheelScrollingEnabledEverywhere
+                                        </Fluent:CheckBox>
                                         <Fluent:CheckBox IsChecked="{Binding IsDefaultContextMenuEnabled, ElementName=ribbon}">
                                             IsDefaultContextMenuEnabled
                                         </Fluent:CheckBox>

--- a/Fluent.Ribbon/Controls/Ribbon.cs
+++ b/Fluent.Ribbon/Controls/Ribbon.cs
@@ -1224,12 +1224,24 @@ public class Ribbon : Control, ILogicalChildSupport
     public static readonly DependencyProperty IsMouseWheelScrollingEnabledProperty = DependencyProperty.Register(nameof(IsMouseWheelScrollingEnabled), typeof(bool), typeof(Ribbon), new PropertyMetadata(BooleanBoxes.TrueBox));
 
     /// <summary>
-    /// Defines whether scrolling by mouse wheel is enabled or not.
+    /// Defines whether scrolling by mouse wheel on the tab container area to cycle tabs is enabled or not.
     /// </summary>
     public bool IsMouseWheelScrollingEnabled
     {
         get { return (bool)this.GetValue(IsMouseWheelScrollingEnabledProperty); }
         set { this.SetValue(IsMouseWheelScrollingEnabledProperty, BooleanBoxes.Box(value)); }
+    }
+
+    /// <summary>Identifies the <see cref="IsMouseWheelScrollingEnabledEverywhere"/> dependency property.</summary>
+    public static readonly DependencyProperty IsMouseWheelScrollingEnabledEverywhereProperty = DependencyProperty.Register(nameof(IsMouseWheelScrollingEnabledEverywhere), typeof(bool), typeof(Ribbon), new PropertyMetadata(BooleanBoxes.FalseBox));
+
+    /// <summary>
+    /// Defines whether scrolling by mouse wheel always cycles selected tab, also outside the tab container area.
+    /// </summary>
+    public bool IsMouseWheelScrollingEnabledEverywhere
+    {
+        get { return (bool)this.GetValue(IsMouseWheelScrollingEnabledEverywhereProperty); }
+        set { this.SetValue(IsMouseWheelScrollingEnabledEverywhereProperty, BooleanBoxes.Box(value)); }
     }
 
     /// <summary>

--- a/Fluent.Ribbon/Controls/RibbonTabControl.cs
+++ b/Fluent.Ribbon/Controls/RibbonTabControl.cs
@@ -386,14 +386,26 @@ public class RibbonTabControl : Selector, IDropDownControl, ILogicalChildSupport
     public static readonly DependencyProperty IsMouseWheelScrollingEnabledProperty = DependencyProperty.Register(nameof(IsMouseWheelScrollingEnabled), typeof(bool), typeof(RibbonTabControl), new PropertyMetadata(BooleanBoxes.TrueBox));
 
     /// <summary>
-    /// Defines whether scrolling by mouse wheel is enabled or not.
+    /// Defines whether scrolling by mouse wheel on the tab container area to cycle tabs is enabled or not.
     /// </summary>
     public bool IsMouseWheelScrollingEnabled
     {
         get { return (bool)this.GetValue(IsMouseWheelScrollingEnabledProperty); }
         set { this.SetValue(IsMouseWheelScrollingEnabledProperty, BooleanBoxes.Box(value)); }
     }
-    
+
+    /// <summary>Identifies the <see cref="IsMouseWheelScrollingEnabledEverywhere"/> dependency property.</summary>
+    public static readonly DependencyProperty IsMouseWheelScrollingEnabledEverywhereProperty = DependencyProperty.Register(nameof(IsMouseWheelScrollingEnabledEverywhere), typeof(bool), typeof(RibbonTabControl), new PropertyMetadata(BooleanBoxes.FalseBox));
+
+    /// <summary>
+    /// Defines whether scrolling by mouse wheel always cycles selected tab, also outside the tab container area.
+    /// </summary>
+    public bool IsMouseWheelScrollingEnabledEverywhere
+    {
+        get { return (bool)this.GetValue(IsMouseWheelScrollingEnabledEverywhereProperty); }
+        set { this.SetValue(IsMouseWheelScrollingEnabledEverywhereProperty, BooleanBoxes.Box(value)); }
+    }
+
     /// <summary>Identifies the <see cref="IsDisplayOptionsButtonVisible"/> dependency property.</summary>
     public static readonly DependencyProperty IsDisplayOptionsButtonVisibleProperty = DependencyProperty.Register(nameof(IsDisplayOptionsButtonVisible), typeof(bool), typeof(RibbonTabControl), new PropertyMetadata(BooleanBoxes.TrueBox));
 
@@ -580,10 +592,21 @@ public class RibbonTabControl : Selector, IDropDownControl, ILogicalChildSupport
     }
 
     /// <inheritdoc />
+    protected override void OnPreviewMouseWheel(MouseWheelEventArgs e)
+    {
+        // If this option is enabled, any scroll is intercepted and used to cycle selected tab.
+        // The wheel event is then never used to scroll the panel content sideways.
+        // If the option is disabled, the wheel event may be used to scroll content.
+        if (this.IsMouseWheelScrollingEnabledEverywhere)
+        {
+            this.ProcessMouseWheel(e);
+        }
+    }
+
+    /// <inheritdoc />
     protected override void OnMouseWheel(MouseWheelEventArgs e)
     {
-        //base.OnPreviewMouseWheel(e);
-
+        // Mouse wheel on tab container may be used to cycle selected tab.
         if (this.IsMouseWheelScrollingEnabled)
         {
             this.ProcessMouseWheel(e);

--- a/Fluent.Ribbon/Themes/Controls/Ribbon.xaml
+++ b/Fluent.Ribbon/Themes/Controls/Ribbon.xaml
@@ -28,6 +28,7 @@
                                          ContextMenu="{Binding ContextMenu, ElementName=PART_LayoutRoot}"
                                          IsDisplayOptionsButtonVisible="{TemplateBinding IsDisplayOptionsButtonVisible}"
                                          IsMouseWheelScrollingEnabled="{TemplateBinding IsMouseWheelScrollingEnabled}"
+                                         IsMouseWheelScrollingEnabledEverywhere="{TemplateBinding IsMouseWheelScrollingEnabledEverywhere}"
                                          IsToolBarVisible="{TemplateBinding IsToolBarVisible}"
                                          Menu="{TemplateBinding Menu}" />
 


### PR DESCRIPTION
Closes #1055 

This adds a new boolean option to use the old-style mouse wheel behavior found in Fluent.Ribbon <=v8 and Office. 

The name of the new option is `IsMouseWheelScrollingEnabledEverywhere`, (and it's frankly not a good name...)

When `true`, the mouse wheel events are caught and used to cycle tabs, regardless of where on the ribbon toolbar the wheel event occurs.  Wen the new option is `false`, the old behavior remains: mouse wheel in the tab area can cycle tab (conditional on the old `IsMouseWheelScrollingEnabled` option). In both cases, the same logic will potentially block the tab shifting, such as if a control has focus. 

If `IsMouseWheelScrollingEnabledEverywhere` is true , then the value of `IsMouseWheelScrollingEnabled` will be ignored.

The default for the new option is `false`.



