### PR TITLE
Fix bugs of Color Gallery and CustomLayout of RibbonToolBar

### DIFF
--- a/Fluent.Ribbon/Controls/ColorGallery.cs
+++ b/Fluent.Ribbon/Controls/ColorGallery.cs
@@ -92,15 +92,15 @@ public class ColorGradientItemTemplateSelector : DataTemplateSelector
         var index = listBox.Items.IndexOf(item);
         if (index < colorGallery.Columns)
         {
-            return listBox.TryFindResource("GradientColorTopDataTemplate") as DataTemplate;
+            return listBox.TryFindResource("Fluent.Ribbon.DataTemplates.GradientColorTopData") as DataTemplate;
         }
 
         if (index >= listBox.Items.Count - colorGallery.Columns)
         {
-            return listBox.TryFindResource("GradientColorBottomDataTemplate") as DataTemplate;
+            return listBox.TryFindResource("Fluent.Ribbon.DataTemplates.GradientColorBottomData") as DataTemplate;
         }
 
-        return listBox.TryFindResource("GradientColorCenterDataTemplate") as DataTemplate;
+        return listBox.TryFindResource("Fluent.Ribbon.DataTemplates.GradientColorCenterData") as DataTemplate;
     }
 }
 

--- a/Fluent.Ribbon/Controls/RibbonToolBar.cs
+++ b/Fluent.Ribbon/Controls/RibbonToolBar.cs
@@ -656,7 +656,7 @@ public class RibbonToolBar : RibbonControl, IRibbonSizeChangedSink, ISimplifiedS
             }
         }
 
-        return new Size(currentMaxX, maxy + whitespace);
+        return new Size(currentMaxX, Math.Max(maxy + whitespace, 0));
     }
 
     // Get the first control and measure, its height accepts as row height


### PR DESCRIPTION
[7bdaba6](https://github.com/fluentribbon/Fluent.Ribbon/pull/1062/commits/7bdaba682295d62a4f102bfb855f10840c59c355)

Some of the Resource keys are not changed.

[e77e9e5](https://github.com/fluentribbon/Fluent.Ribbon/pull/1062/commits/e77e9e583a31e94630873a8d082af6ef8cdb5051)

This change is trying to fix Size constructor get a negative of height and an exception will throw.
The `whitespace` is calculated by a division expression, and cause a precision error when devide by 3. 