### PR TITLE
Fix InvalidOperationException thrown when switching focus from editable ComboBox to Hyperlink

### DIFF
--- a/Fluent.Ribbon/Extensions/ItemContainerGeneratorExtensions.cs
+++ b/Fluent.Ribbon/Extensions/ItemContainerGeneratorExtensions.cs
@@ -3,6 +3,7 @@
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
+using Fluent.Internal;
 
 /// <summary>
 /// Extension-Methods for <see cref="ItemContainerGenerator" />.
@@ -82,7 +83,7 @@ public static class ItemContainerGeneratorExtensions
             return item;
         }
 
-        var visualParent = VisualTreeHelper.GetParent(container);
+        var visualParent = UIHelper.GetVisualParent(container);
         if (visualParent is not null)
         {
             item = @this.ItemFromContainer(visualParent);


### PR DESCRIPTION
An InvalidOperationException thrown when switching focus from editable ComboBox to Hyperlink. I searched the issues and found #464  . So I fix it using the same way.

Exception Message:
'System.Windows.Documents.Hyperlink' is not a Visual or Visual3D.

Exception Call Stack:
```
   at MS.Internal.Media.VisualTreeUtils.AsVisual(DependencyObject element, Visual& visual, Visual3D& visual3D)
   at System.Windows.Media.VisualTreeHelper.GetParent(DependencyObject reference)
   at Fluent.Extensions.ItemContainerGeneratorExtensions.ItemFromContainerOrContainerContent(ItemContainerGenerator this, DependencyObject container) in D:\\Github\\Fork\\Fluent.Ribbon\\Fluent.Ribbon\\Extensions\\ItemContainerGeneratorExtensions.cs:line 85
   at Fluent.ComboBox.OnFocusedElementLostKeyboardFocus(Object sender, KeyboardFocusChangedEventArgs e) in D:\\Github\\Fork\\Fluent.Ribbon\\Fluent.Ribbon\\Controls\\ComboBox.cs:line 732
   at System.Windows.RoutedEventArgs.InvokeHandler(Delegate handler, Object target)
   at System.Windows.EventRoute.InvokeHandlersImpl(Object source, RoutedEventArgs args, Boolean reRaised)
   at System.Windows.UIElement.RaiseEventImpl(DependencyObject sender, RoutedEventArgs args)
   at System.Windows.UIElement.RaiseTrustedEvent(RoutedEventArgs args)
   at System.Windows.Input.InputManager.ProcessStagingArea()
   at System.Windows.Input.KeyboardDevice.ChangeFocus(DependencyObject focus, Int32 timestamp)
   at System.Windows.Input.KeyboardDevice.Focus(DependencyObject focus, Boolean askOld, Boolean askNew, Boolean forceToNullIfFailed)
   at System.Windows.Input.KeyboardDevice.Focus(IInputElement element)
   at System.Windows.ContentElement.Focus()
   at System.Windows.Documents.Hyperlink.OnMouseLeftButtonDown(Object sender, MouseButtonEventArgs e)
   at System.Windows.Documents.Hyperlink.OnMouseLeftButtonDown(MouseButtonEventArgs e)
   at System.Windows.RoutedEventArgs.InvokeHandler(Delegate handler, Object target)
   at System.Windows.EventRoute.InvokeHandlersImpl(Object source, RoutedEventArgs args, Boolean reRaised)
   at System.Windows.UIElement.ReRaiseEventAs(DependencyObject sender, RoutedEventArgs args, RoutedEvent newEvent)
   at System.Windows.RoutedEventArgs.InvokeHandler(Delegate handler, Object target)
   at System.Windows.EventRoute.InvokeHandlersImpl(Object source, RoutedEventArgs args, Boolean reRaised)
   at System.Windows.UIElement.RaiseEventImpl(DependencyObject sender, RoutedEventArgs args)
   at System.Windows.UIElement.RaiseTrustedEvent(RoutedEventArgs args)
   at System.Windows.Input.InputManager.ProcessStagingArea()
   at System.Windows.Input.InputProviderSite.ReportInput(InputReport inputReport)
   at System.Windows.Interop.HwndMouseInputProvider.ReportInput(IntPtr hwnd, InputMode mode, Int32 timestamp, RawMouseActions actions, Int32 x, Int32 y, Int32 wheel)
   at System.Windows.Interop.HwndMouseInputProvider.FilterMessage(IntPtr hwnd, WindowMessage msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
   at System.Windows.Interop.HwndSource.InputFilterMessage(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
   at MS.Win32.HwndWrapper.WndProc(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
   at MS.Win32.HwndSubclass.DispatcherCallbackOperation(Object o)
   at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
   at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
```