### PR TITLE
Fix on some computers, the gallery layout is not good

### DIFF
--- a/Fluent.Ribbon/Controls/UniformGridWithItemSize.cs
+++ b/Fluent.Ribbon/Controls/UniformGridWithItemSize.cs
@@ -212,7 +212,7 @@ public class UniformGridWithItemSize : Panel
             {
                 childBounds.X += xStep;
 
-                if (childBounds.X >= xBound)
+                if (DoubleUtil.GreaterThan(childBounds.X, xBound) || DoubleUtil.AreClose(childBounds.X, xBound))
                 {
                     childBounds.Y += childBounds.Height;
                     childBounds.X = 0;


### PR DESCRIPTION
On some computers, the gallery's layout may become like this.

![image](https://user-images.githubusercontent.com/25047407/209653602-8d538217-faa1-44dc-9d08-ce1a476c44e5.png)

I found `childBounds.X >= xBound`. The `childBounds.X` is 232.39999999... , but the xBound is 232.4. So the 7th gallery item renders in an incorrect position. 