### PR TITLE
Ensure that a tooltip added to the BackstageTabItem is only shown whe…

### DIFF
--- a/Fluent.Ribbon.Showcase/TestContent.xaml
+++ b/Fluent.Ribbon.Showcase/TestContent.xaml
@@ -206,6 +206,10 @@
                             <Fluent:BackstageTabItem Header="Introduction"
                                                      Icon="{DynamicResource Fluent.Ribbon.Images.DefaultPlaceholder}"
                                                      KeyTip="T">
+                                <Fluent:BackstageTabItem.ToolTip>
+                                    <Fluent:ScreenTip Title="Introduction"
+                                                      Text="This is a sample for a backstageitem with content" />
+                                </Fluent:BackstageTabItem.ToolTip>
                                 <StackPanel Orientation="Vertical">
                                     <TextBlock>This is a BackstageTabItem with some sample content.</TextBlock>
 

--- a/Fluent.Ribbon/Themes/Controls/BackstageTabItem.xaml
+++ b/Fluent.Ribbon/Themes/Controls/BackstageTabItem.xaml
@@ -5,7 +5,9 @@
     <ControlTemplate x:Key="Fluent.Ribbon.Templates.BackstageTabItem"
                      TargetType="{x:Type Fluent:BackstageTabItem}">
         <Grid x:Name="rootGrid"
-              Background="Transparent">
+              Background="Transparent"
+              ToolTip="{TemplateBinding ToolTip}">
+
             <Border x:Name="selectedBorder"
                     Margin="0"
                     Background="{TemplateBinding Fluent:RibbonProperties.IsSelectedBackground}"
@@ -67,6 +69,7 @@
         <Setter Property="Foreground" Value="{DynamicResource Fluent.Ribbon.Brushes.Black}" />
         <Setter Property="Height" Value="38" />
         <Setter Property="Margin" Value="0" />
+        <Setter Property="ToolTipService.IsEnabled" Value="False" />
         <Setter Property="Template" Value="{DynamicResource Fluent.Ribbon.Templates.BackstageTabItem}" />
     </Style>
 </ResourceDictionary>


### PR DESCRIPTION
…n the user hovers over the Button.

Fixed by moving the tooltip inside the controltemplate, and disabling it content-wide.

Added test-case to the showcase.

Fix for #1096 