### PR TITLE
Ribbontabitemkeyboardfix

### DIFF
--- a/Fluent.Ribbon/Controls/RibbonTabControl.cs
+++ b/Fluent.Ribbon/Controls/RibbonTabControl.cs
@@ -634,6 +634,11 @@ public class RibbonTabControl : Selector, IDropDownControl, ILogicalChildSupport
                 if (this.IsDropDownOpen)
                 {
                     this.IsDropDownOpen = false;
+
+                    if (this.IsKeyboardFocusWithin)
+                    {
+                        this.GetSelectedTabItem()?.Focus();
+                    }
                 }
 
                 break;

--- a/Fluent.Ribbon/Controls/RibbonTabControl.cs
+++ b/Fluent.Ribbon/Controls/RibbonTabControl.cs
@@ -565,14 +565,7 @@ public class RibbonTabControl : Selector, IDropDownControl, ILogicalChildSupport
             newSelectedItem?.Focus();
         }
 
-        if (e.AddedItems.Count > 0)
-        {
-            if (this.IsMinimized)
-            {
-                this.IsDropDownOpen = true;
-            }
-        }
-        else
+        if (e.AddedItems.Count == 0)
         {
             if (this.IsDropDownOpen)
             {

--- a/Fluent.Ribbon/Controls/RibbonTabControl.cs
+++ b/Fluent.Ribbon/Controls/RibbonTabControl.cs
@@ -546,14 +546,23 @@ public class RibbonTabControl : Selector, IDropDownControl, ILogicalChildSupport
     /// <inheritdoc />
     protected override void OnSelectionChanged(SelectionChangedEventArgs e)
     {
+        var newSelectedItem = e.AddedItems.Count > 0
+            ? (RibbonTabItem?)e.AddedItems[0]
+            : null;
+
+        if (this.SelectedTabItem is not null
+            && ReferenceEquals(this.SelectedTabItem, newSelectedItem) == false)
+        {
+            this.SelectedTabItem.IsSelected = false;
+        }
+
         this.UpdateSelectedContent();
 
         if (this.IsKeyboardFocusWithin
             && this.IsMinimized == false)
         {
             // If keyboard focus is within the control, make sure it is going to the correct place
-            var item = this.GetSelectedTabItem();
-            item?.Focus();
+            newSelectedItem?.Focus();
         }
 
         if (e.AddedItems.Count > 0)
@@ -561,13 +570,6 @@ public class RibbonTabControl : Selector, IDropDownControl, ILogicalChildSupport
             if (this.IsMinimized)
             {
                 this.IsDropDownOpen = true;
-
-                var ribbonTabItem = (RibbonTabItem?)e.AddedItems[0];
-
-                if (ribbonTabItem is not null)
-                {
-                    ribbonTabItem.IsHitTestVisible = false;
-                }
             }
         }
         else
@@ -575,16 +577,6 @@ public class RibbonTabControl : Selector, IDropDownControl, ILogicalChildSupport
             if (this.IsDropDownOpen)
             {
                 this.IsDropDownOpen = false;
-            }
-        }
-
-        if (e.RemovedItems.Count > 0)
-        {
-            var ribbonTabItem = (RibbonTabItem?)e.RemovedItems[0];
-
-            if (ribbonTabItem is not null)
-            {
-                ribbonTabItem.IsHitTestVisible = true;
             }
         }
 

--- a/Fluent.Ribbon/Controls/RibbonTabItem.cs
+++ b/Fluent.Ribbon/Controls/RibbonTabItem.cs
@@ -642,6 +642,7 @@ public class RibbonTabItem : Control, IKeyTipedControl, IHeaderedControl, ILogic
                     else
                     {
                         this.TabControlParent.SelectedItem = newItem;
+                        this.TabControlParent.IsDropDownOpen = true;
                     }
 
                     this.TabControlParent.RaiseRequestBackstageClose();
@@ -654,6 +655,24 @@ public class RibbonTabItem : Control, IKeyTipedControl, IHeaderedControl, ILogic
                 e.Handled = true;
             }
         }
+    }
+
+    /// <inheritdoc />
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        switch (e.Key)
+        {
+            case Key.Enter:
+            case Key.Space:
+                if (this.TabControlParent is not null)
+                {
+                    this.TabControlParent.IsDropDownOpen = true;
+                }
+
+                break;
+        }
+
+        base.OnKeyDown(e);
     }
 
     /// <inheritdoc />

--- a/Fluent.Ribbon/Controls/RibbonTabItem.cs
+++ b/Fluent.Ribbon/Controls/RibbonTabItem.cs
@@ -667,6 +667,15 @@ public class RibbonTabItem : Control, IKeyTipedControl, IHeaderedControl, ILogic
                 if (this.TabControlParent is not null)
                 {
                     this.TabControlParent.IsDropDownOpen = true;
+
+                    if (this.TabControlParent.DropDownPopup is not null)
+                    {
+                        var focusElement = UIHelper.FindFirstFocusableElement(this.TabControlParent.DropDownPopup.Child);
+                        if (focusElement is not null)
+                        {
+                            Keyboard.Focus(focusElement);
+                        }
+                    }
                 }
 
                 break;

--- a/Fluent.Ribbon/Controls/RibbonTabItem.cs
+++ b/Fluent.Ribbon/Controls/RibbonTabItem.cs
@@ -679,17 +679,15 @@ public class RibbonTabItem : Control, IKeyTipedControl, IHeaderedControl, ILogic
 
         if (newValue)
         {
-            if (container.TabControlParent?.SelectedTabItem is not null
-                && ReferenceEquals(container.TabControlParent.SelectedTabItem, container) == false)
-            {
-                container.TabControlParent.SelectedTabItem.IsSelected = false;
-            }
-
             container.OnSelected(new RoutedEventArgs(Selector.SelectedEvent, container));
+
+            container.IsHitTestVisible = false;
         }
         else
         {
             container.OnUnselected(new RoutedEventArgs(Selector.UnselectedEvent, container));
+
+            container.IsHitTestVisible = true;
         }
 
         // Raise UI automation events on this RibbonTabItem

--- a/Fluent.Ribbon/Controls/RibbonTabItem.cs
+++ b/Fluent.Ribbon/Controls/RibbonTabItem.cs
@@ -657,6 +657,14 @@ public class RibbonTabItem : Control, IKeyTipedControl, IHeaderedControl, ILogic
     }
 
     /// <inheritdoc />
+    protected override void OnGotKeyboardFocus(KeyboardFocusChangedEventArgs e)
+    {
+        base.OnGotKeyboardFocus(e);
+
+        this.SetCurrentValue(IsSelectedProperty, BooleanBoxes.TrueBox);
+    }
+
+    /// <inheritdoc />
     protected override AutomationPeer OnCreateAutomationPeer() => new Fluent.Automation.Peers.RibbonTabItemAutomationPeer(this);
 
     #endregion

--- a/Fluent.Ribbon/Services/KeyTipService.cs
+++ b/Fluent.Ribbon/Services/KeyTipService.cs
@@ -490,15 +490,11 @@ public class KeyTipService
             this.backUpFocusedControl = FocusWrapper.GetWrapperForCurrentFocus();
         }
 
-        if (keyTipsTarget is Ribbon
-            {
-                IsMinimized: false,
-                SelectedTabIndex: >= 0,
-                TabControl: { }
-            })
+        if (keyTipsTarget is Ribbon && this.ribbon.TabControl != null)
         {
             // Focus ribbon
-            (this.ribbon.TabControl?.ItemContainerGenerator.ContainerFromIndex(this.ribbon.TabControl.SelectedIndex) as UIElement)?.Focus();
+            int selectedIndex = Math.Max(this.ribbon.TabControl.SelectedIndex, 0);
+            (this.ribbon.TabControl.ItemContainerGenerator.ContainerFromIndex(selectedIndex) as UIElement)?.Focus();
         }
 
         this.ClearUserInput();


### PR DESCRIPTION
#772 

Added changes to make navigation with the keyboard in the tabitems accessible.

It now follows the Office ribbon scheme which is:
- The KeyTip key (Alt) sets focus in the selected tabitem, otherwise it selects the first tab.
- Navigation between the tabs with the arrow keys now select the tab on getting focus.
- When the ribbon is minimized the dropdown can be opened via Enter or Space.
- When the ribbon is minimized and a tab is opened, focus is also set in the tab.
- When the ribbon is minimized and the tab dropdown is closed, focus is moved back into the tabitem.