### PR TITLE
Fix combobox can't open dropdown when the editable textbox of it has the focus

### DIFF
--- a/Fluent.Ribbon/Controls/ComboBox.cs
+++ b/Fluent.Ribbon/Controls/ComboBox.cs
@@ -658,7 +658,11 @@ public class ComboBox : System.Windows.Controls.ComboBox, IQuickAccessItemProvid
 
         if (this.SelectedItem is not null)
         {
-            Keyboard.Focus(this.ItemContainerGenerator.ContainerOrContainerContentFromItem<IInputElement>(this.SelectedItem));
+            var selectedItemContainser = this.ItemContainerGenerator.ContainerOrContainerContentFromItem<IInputElement>(this.SelectedItem);
+            if (selectedItemContainser is not null)
+            {
+                Keyboard.Focus(selectedItemContainser);
+            }
         }
 
         this.focusedElement = Keyboard.FocusedElement;

--- a/Fluent.Ribbon/Controls/ComboBox.cs
+++ b/Fluent.Ribbon/Controls/ComboBox.cs
@@ -658,10 +658,10 @@ public class ComboBox : System.Windows.Controls.ComboBox, IQuickAccessItemProvid
 
         if (this.SelectedItem is not null)
         {
-            var selectedItemContainser = this.ItemContainerGenerator.ContainerOrContainerContentFromItem<IInputElement>(this.SelectedItem);
-            if (selectedItemContainser is not null)
+            var selectedItemContainer = this.ItemContainerGenerator.ContainerOrContainerContentFromItem<IInputElement>(this.SelectedItem);
+            if (selectedItemContainer is not null)
             {
-                Keyboard.Focus(selectedItemContainser);
+                Keyboard.Focus(selectedItemContainer);
             }
         }
 


### PR DESCRIPTION
The code has detected the SelectedItem is not null, and I think it's better to detect container is not null too. Especially when the ComboBox dropdown is never open.  

If the given target of the `Keyboard.Focus` method is null, the keyboard will focus to the RootVisual like MainWindow. It causes the keyboard focus changes if the keyboard has been already focused on it. But in .NET WPF code, when the IsKeyboardFocusWithin changed, it may cause the dropdown closed immediately. 

![image](https://user-images.githubusercontent.com/25047407/224663606-e428b5ab-7ddc-4f8a-8317-cb1d33a03f05.png)