### PR TITLE
Fixing binding path to attached property for simplified ControlTemplates

### DIFF
--- a/Fluent.Ribbon/Themes/Controls/Button.xaml
+++ b/Fluent.Ribbon/Themes/Controls/Button.xaml
@@ -140,7 +140,7 @@
                       HorizontalAlignment="Center"
                       VerticalAlignment="Center">
                     <Fluent:IconPresenter x:Name="iconImage"
-                                          IconSize="{Binding (Fluent:RibbonProperties.IconSize), RelativeSource={RelativeSource TemplatedParent}}"
+                                          IconSize="{Binding Path=(Fluent:RibbonProperties.IconSize), RelativeSource={RelativeSource TemplatedParent}}"
                                           LargeIcon="{Binding LargeIcon, RelativeSource={RelativeSource TemplatedParent}}"
                                           MediumIcon="{Binding MediumIcon, RelativeSource={RelativeSource TemplatedParent}}"
                                           SmallIcon="{Binding Icon, RelativeSource={RelativeSource TemplatedParent}}" />

--- a/Fluent.Ribbon/Themes/Controls/DropDownButton.xaml
+++ b/Fluent.Ribbon/Themes/Controls/DropDownButton.xaml
@@ -222,7 +222,7 @@
                           HorizontalAlignment="Center"
                           VerticalAlignment="Center">
                         <Fluent:IconPresenter x:Name="iconImage"
-                                              IconSize="{Binding (Fluent:RibbonProperties.IconSize), RelativeSource={RelativeSource TemplatedParent}}"
+                                              IconSize="{Binding Path=(Fluent:RibbonProperties.IconSize), RelativeSource={RelativeSource TemplatedParent}}"
                                               LargeIcon="{Binding LargeIcon, RelativeSource={RelativeSource TemplatedParent}}"
                                               MediumIcon="{Binding MediumIcon, RelativeSource={RelativeSource TemplatedParent}}"
                                               SmallIcon="{Binding Icon, RelativeSource={RelativeSource TemplatedParent}}" />

--- a/Fluent.Ribbon/Themes/Controls/InRibbonGallery.xaml
+++ b/Fluent.Ribbon/Themes/Controls/InRibbonGallery.xaml
@@ -172,7 +172,7 @@
                       HorizontalAlignment="Center"
                       VerticalAlignment="Center">
                     <Fluent:IconPresenter x:Name="iconImage"
-                                          IconSize="{Binding (Fluent:RibbonProperties.IconSize), RelativeSource={RelativeSource TemplatedParent}}"
+                                          IconSize="{Binding Path=(Fluent:RibbonProperties.IconSize), RelativeSource={RelativeSource TemplatedParent}}"
                                           LargeIcon="{Binding LargeIcon, RelativeSource={RelativeSource TemplatedParent}}"
                                           MediumIcon="{Binding MediumIcon, RelativeSource={RelativeSource TemplatedParent}}"
                                           SmallIcon="{Binding Icon, RelativeSource={RelativeSource TemplatedParent}}" />

--- a/Fluent.Ribbon/Themes/Controls/RibbonGroupBox.xaml
+++ b/Fluent.Ribbon/Themes/Controls/RibbonGroupBox.xaml
@@ -529,7 +529,7 @@
                           VerticalAlignment="Center"
                           IsHitTestVisible="False">
                         <Fluent:IconPresenter x:Name="iconImage"
-                                              IconSize="{Binding (Fluent:RibbonProperties.IconSize), RelativeSource={RelativeSource TemplatedParent}}"
+                                              IconSize="{Binding Path=(Fluent:RibbonProperties.IconSize), RelativeSource={RelativeSource TemplatedParent}}"
                                               MediumIcon="{Binding MediumIcon, RelativeSource={RelativeSource TemplatedParent}}"
                                               SmallIcon="{Binding Icon, RelativeSource={RelativeSource TemplatedParent}}" />
                         <Border Margin="0"

--- a/Fluent.Ribbon/Themes/Controls/Spinner.xaml
+++ b/Fluent.Ribbon/Themes/Controls/Spinner.xaml
@@ -237,7 +237,7 @@
                     <Fluent:IconPresenter x:Name="iconImage"
                                           Margin="0 0 4 0"
                                           VerticalAlignment="Center"
-                                          IconSize="{Binding (Fluent:RibbonProperties.IconSize), RelativeSource={RelativeSource TemplatedParent}}"
+                                          IconSize="{Binding Path=(Fluent:RibbonProperties.IconSize), RelativeSource={RelativeSource TemplatedParent}}"
                                           MediumIcon="{Binding MediumIcon, RelativeSource={RelativeSource TemplatedParent}}"
                                           SmallIcon="{Binding Icon, RelativeSource={RelativeSource TemplatedParent}}" />
 

--- a/Fluent.Ribbon/Themes/Controls/SplitButton.xaml
+++ b/Fluent.Ribbon/Themes/Controls/SplitButton.xaml
@@ -458,7 +458,7 @@
                       HorizontalAlignment="Center"
                       VerticalAlignment="Center">
                     <Fluent:IconPresenter x:Name="iconImage"
-                                          IconSize="{Binding (Fluent:RibbonProperties.IconSize), RelativeSource={RelativeSource TemplatedParent}}"
+                                          IconSize="{Binding Path=(Fluent:RibbonProperties.IconSize), RelativeSource={RelativeSource TemplatedParent}}"
                                           LargeIcon="{Binding LargeIcon, RelativeSource={RelativeSource TemplatedParent}}"
                                           MediumIcon="{Binding MediumIcon, RelativeSource={RelativeSource TemplatedParent}}"
                                           SmallIcon="{Binding Icon, RelativeSource={RelativeSource TemplatedParent}}" />

--- a/Fluent.Ribbon/Themes/Controls/ToggleButton.xaml
+++ b/Fluent.Ribbon/Themes/Controls/ToggleButton.xaml
@@ -153,7 +153,7 @@
                       VerticalAlignment="Center">
                     <Fluent:IconPresenter x:Name="iconImage"
                                           Margin="0"
-                                          IconSize="{Binding (Fluent:RibbonProperties.IconSize), RelativeSource={RelativeSource TemplatedParent}}"
+                                          IconSize="{Binding Path=(Fluent:RibbonProperties.IconSize), RelativeSource={RelativeSource TemplatedParent}}"
                                           LargeIcon="{Binding LargeIcon, RelativeSource={RelativeSource TemplatedParent}}"
                                           MediumIcon="{Binding MediumIcon, RelativeSource={RelativeSource TemplatedParent}}"
                                           SmallIcon="{Binding Icon, RelativeSource={RelativeSource TemplatedParent}}" />


### PR DESCRIPTION
see https://github.com/fluentribbon/Fluent.Ribbon/issues/1132#issue-1706190155