### PR TITLE
Avoid forcing the first tab if there already is another tab selected,…

### DIFF
--- a/Fluent.Ribbon/Controls/Ribbon.cs
+++ b/Fluent.Ribbon/Controls/Ribbon.cs
@@ -1936,7 +1936,10 @@ public class Ribbon : Control, ILogicalChildSupport
 
         this.RibbonStateStorage.Load();
 
-        this.TabControl?.SelectFirstTab();
+        if (this.SelectedTabItem is null)
+        {
+            this.TabControl?.SelectFirstTab();
+        }
     }
 
     #endregion


### PR DESCRIPTION
… either due to a binding or because the ribbon is unloaded/loaded due to a system event.

#1218