### PR TITLE
Set Icon properties as NonLocalizable

### DIFF
--- a/Fluent.Ribbon/Controls/BackstageTabItem.cs
+++ b/Fluent.Ribbon/Controls/BackstageTabItem.cs
@@ -24,6 +24,8 @@ public class BackstageTabItem : ContentControl, IHeaderedControl, IKeyTipedContr
     /// <summary>
     /// Gets or sets Icon for the element
     /// </summary>
+    [Localizability(LocalizationCategory.NeverLocalize)]
+    [Localizable(false)]
     public object? Icon
     {
         get => this.GetValue(IconProperty);

--- a/Fluent.Ribbon/Controls/Button.cs
+++ b/Fluent.Ribbon/Controls/Button.cs
@@ -2,6 +2,7 @@
 namespace Fluent;
 
 using System.Collections;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Windows;
 using System.Windows.Automation.Peers;
@@ -114,6 +115,8 @@ public class Button : System.Windows.Controls.Button, IRibbonControl, IQuickAcce
     #region Icon
 
     /// <inheritdoc />
+    [Localizability(LocalizationCategory.NeverLocalize)]
+    [Localizable(false)]
     public object? Icon
     {
         get => this.GetValue(IconProperty);
@@ -128,6 +131,8 @@ public class Button : System.Windows.Controls.Button, IRibbonControl, IQuickAcce
     #region LargeIcon
 
     /// <inheritdoc />
+    [Localizability(LocalizationCategory.NeverLocalize)]
+    [Localizable(false)]
     public object? LargeIcon
     {
         get => this.GetValue(LargeIconProperty);
@@ -142,6 +147,8 @@ public class Button : System.Windows.Controls.Button, IRibbonControl, IQuickAcce
     #region MediumIcon
 
     /// <inheritdoc />
+    [Localizability(LocalizationCategory.NeverLocalize)]
+    [Localizable(false)]
     public object? MediumIcon
     {
         get => this.GetValue(MediumIconProperty);

--- a/Fluent.Ribbon/Controls/CheckBox.cs
+++ b/Fluent.Ribbon/Controls/CheckBox.cs
@@ -2,6 +2,7 @@
 namespace Fluent;
 
 using System.Collections;
+using System.ComponentModel;
 using System.Windows;
 using System.Windows.Automation.Peers;
 using System.Windows.Controls;
@@ -114,6 +115,8 @@ public class CheckBox : System.Windows.Controls.CheckBox, IRibbonControl, IQuick
     #region Icon
 
     /// <inheritdoc />
+    [Localizability(LocalizationCategory.NeverLocalize)]
+    [Localizable(false)]
     public object? Icon
     {
         get => this.GetValue(IconProperty);
@@ -128,6 +131,8 @@ public class CheckBox : System.Windows.Controls.CheckBox, IRibbonControl, IQuick
     #region LargeIcon
 
     /// <inheritdoc />
+    [Localizability(LocalizationCategory.NeverLocalize)]
+    [Localizable(false)]
     public object? LargeIcon
     {
         get => this.GetValue(LargeIconProperty);
@@ -142,6 +147,8 @@ public class CheckBox : System.Windows.Controls.CheckBox, IRibbonControl, IQuick
     #region MediumIcon
 
     /// <inheritdoc />
+    [Localizability(LocalizationCategory.NeverLocalize)]
+    [Localizable(false)]
     public object? MediumIcon
     {
         get => this.GetValue(MediumIconProperty);

--- a/Fluent.Ribbon/Controls/ComboBox.cs
+++ b/Fluent.Ribbon/Controls/ComboBox.cs
@@ -3,6 +3,7 @@ namespace Fluent;
 
 using System;
 using System.Collections;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Windows;
 using System.Windows.Automation.Peers;
@@ -149,6 +150,8 @@ public class ComboBox : System.Windows.Controls.ComboBox, IQuickAccessItemProvid
     #region Icon
 
     /// <inheritdoc />
+    [Localizability(LocalizationCategory.NeverLocalize)]
+    [Localizable(false)]
     public object? Icon
     {
         get => this.GetValue(IconProperty);
@@ -163,6 +166,8 @@ public class ComboBox : System.Windows.Controls.ComboBox, IQuickAccessItemProvid
     #region MediumIcon
 
     /// <inheritdoc />
+    [Localizability(LocalizationCategory.NeverLocalize)]
+    [Localizable(false)]
     public object? MediumIcon
     {
         get => this.GetValue(MediumIconProperty);

--- a/Fluent.Ribbon/Controls/DropDownButton.cs
+++ b/Fluent.Ribbon/Controls/DropDownButton.cs
@@ -4,6 +4,7 @@ namespace Fluent;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using System.Windows;
@@ -164,6 +165,8 @@ public class DropDownButton : ItemsControl, IQuickAccessItemProvider, IRibbonCon
     #region Icon
 
     /// <inheritdoc />
+    [Localizability(LocalizationCategory.NeverLocalize)]
+    [Localizable(false)]
     public object? Icon
     {
         get => this.GetValue(IconProperty);
@@ -178,6 +181,8 @@ public class DropDownButton : ItemsControl, IQuickAccessItemProvider, IRibbonCon
     #region LargeIcon
 
     /// <inheritdoc />
+    [Localizability(LocalizationCategory.NeverLocalize)]
+    [Localizable(false)]
     public object? LargeIcon
     {
         get => this.GetValue(LargeIconProperty);
@@ -192,6 +197,8 @@ public class DropDownButton : ItemsControl, IQuickAccessItemProvider, IRibbonCon
     #region MediumIcon
 
     /// <inheritdoc />
+    [Localizability(LocalizationCategory.NeverLocalize)]
+    [Localizable(false)]
     public object? MediumIcon
     {
         get => this.GetValue(MediumIconProperty);

--- a/Fluent.Ribbon/Controls/InRibbonGallery.cs
+++ b/Fluent.Ribbon/Controls/InRibbonGallery.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
+using System.ComponentModel;
 using System.Linq;
 using System.Windows;
 using System.Windows.Automation.Peers;
@@ -168,6 +169,8 @@ public class InRibbonGallery : Selector, IScalableRibbonControl, IDropDownContro
     #region Icon
 
     /// <inheritdoc />
+    [Localizability(LocalizationCategory.NeverLocalize)]
+    [Localizable(false)]
     public object? Icon
     {
         get => this.GetValue(IconProperty);
@@ -745,6 +748,8 @@ public class InRibbonGallery : Selector, IScalableRibbonControl, IDropDownContro
     #region LargeIcon
 
     /// <inheritdoc />
+    [Localizability(LocalizationCategory.NeverLocalize)]
+    [Localizable(false)]
     public object? LargeIcon
     {
         get => this.GetValue(LargeIconProperty);
@@ -759,6 +764,8 @@ public class InRibbonGallery : Selector, IScalableRibbonControl, IDropDownContro
     #region MediumIcon
 
     /// <inheritdoc />
+    [Localizability(LocalizationCategory.NeverLocalize)]
+    [Localizable(false)]
     public object? MediumIcon
     {
         get => this.GetValue(MediumIconProperty);

--- a/Fluent.Ribbon/Controls/RadioButton.cs
+++ b/Fluent.Ribbon/Controls/RadioButton.cs
@@ -2,6 +2,7 @@
 namespace Fluent;
 
 using System.Collections;
+using System.ComponentModel;
 using System.Windows;
 using System.Windows.Automation.Peers;
 using System.Windows.Controls;
@@ -114,6 +115,8 @@ public class RadioButton : System.Windows.Controls.RadioButton, IRibbonControl, 
     #region Icon
 
     /// <inheritdoc />
+    [Localizability(LocalizationCategory.NeverLocalize)]
+    [Localizable(false)]
     public object? Icon
     {
         get => this.GetValue(IconProperty);
@@ -142,6 +145,8 @@ public class RadioButton : System.Windows.Controls.RadioButton, IRibbonControl, 
     #region MediumIcon
 
     /// <inheritdoc />
+    [Localizability(LocalizationCategory.NeverLocalize)]
+    [Localizable(false)]
     public object? MediumIcon
     {
         get => this.GetValue(MediumIconProperty);

--- a/Fluent.Ribbon/Controls/RibbonControl.cs
+++ b/Fluent.Ribbon/Controls/RibbonControl.cs
@@ -83,6 +83,8 @@ public abstract class RibbonControl : Control, ICommandSource, IQuickAccessItemP
     #region Icon
 
     /// <inheritdoc />
+    [Localizability(LocalizationCategory.NeverLocalize)]
+    [Localizable(false)]
     public object? Icon
     {
         get => this.GetValue(IconProperty);

--- a/Fluent.Ribbon/Controls/RibbonGroupBox.cs
+++ b/Fluent.Ribbon/Controls/RibbonGroupBox.cs
@@ -567,6 +567,8 @@ public class RibbonGroupBox : HeaderedItemsControl, IQuickAccessItemProvider, ID
     /// <summary>
     /// Gets or sets icon
     /// </summary>
+    [Localizability(LocalizationCategory.NeverLocalize)]
+    [Localizable(false)]
     public object? Icon
     {
         get => this.GetValue(IconProperty);
@@ -581,6 +583,8 @@ public class RibbonGroupBox : HeaderedItemsControl, IQuickAccessItemProvider, ID
     #region MediumIcon
 
     /// <inheritdoc />
+    [Localizability(LocalizationCategory.NeverLocalize)]
+    [Localizable(false)]
     public object? MediumIcon
     {
         get => this.GetValue(MediumIconProperty);
@@ -595,6 +599,8 @@ public class RibbonGroupBox : HeaderedItemsControl, IQuickAccessItemProvider, ID
     #region LargeIcon
 
     /// <inheritdoc />
+    [Localizability(LocalizationCategory.NeverLocalize)]
+    [Localizable(false)]
     public object? LargeIcon
     {
         get => this.GetValue(LargeIconProperty);

--- a/Fluent.Ribbon/Controls/Spinner.cs
+++ b/Fluent.Ribbon/Controls/Spinner.cs
@@ -3,6 +3,7 @@ namespace Fluent;
 
 using System;
 using System.Collections;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.Windows;
@@ -55,6 +56,8 @@ public class Spinner : RibbonControl, IMediumIconProvider, ISimplifiedRibbonCont
     #region MediumIcon
 
     /// <inheritdoc />
+    [Localizability(LocalizationCategory.NeverLocalize)]
+    [Localizable(false)]
     public object? MediumIcon
     {
         get => this.GetValue(MediumIconProperty);

--- a/Fluent.Ribbon/Controls/ToggleButton.cs
+++ b/Fluent.Ribbon/Controls/ToggleButton.cs
@@ -2,6 +2,7 @@
 namespace Fluent;
 
 using System.Collections;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Windows;
 using System.Windows.Automation.Peers;
@@ -129,6 +130,8 @@ public class ToggleButton : System.Windows.Controls.Primitives.ToggleButton, ITo
     #region Icon
 
     /// <inheritdoc />
+    [Localizability(LocalizationCategory.NeverLocalize)]
+    [Localizable(false)]
     public object? Icon
     {
         get => this.GetValue(IconProperty);
@@ -143,6 +146,8 @@ public class ToggleButton : System.Windows.Controls.Primitives.ToggleButton, ITo
     #region LargeIcon
 
     /// <inheritdoc />
+    [Localizability(LocalizationCategory.NeverLocalize)]
+    [Localizable(false)]
     public object? LargeIcon
     {
         get => this.GetValue(LargeIconProperty);
@@ -157,6 +162,8 @@ public class ToggleButton : System.Windows.Controls.Primitives.ToggleButton, ITo
     #region MediumIcon
 
     /// <inheritdoc />
+    [Localizability(LocalizationCategory.NeverLocalize)]
+    [Localizable(false)]
     public object? MediumIcon
     {
         get => this.GetValue(MediumIconProperty);


### PR DESCRIPTION
Pull request for the issue: #1222 

What changed:
Set the [Localizability(LocalizationCategory.NeverLocalize)] and [Localizable(false)] attributes on Icon properties of the controls, so that translation tools do not consider value of Icon property for localizing.

Example:
Before translation
Icon="pack://application:,,,/xxxLibrary;component/Icons/16x16/icnExit.png"

After psuedo translation
Icon="tr_pack://application:,,,/Nmx.Workplace.Library.StyleLibrary;component/Icons/16x16/icnExit.png_tr"