### PR TITLE
General purpose fix for missing/untransfered ItemsControl QAT properties

### DIFF
--- a/Fluent.Ribbon/Controls/RibbonControl.cs
+++ b/Fluent.Ribbon/Controls/RibbonControl.cs
@@ -13,6 +13,8 @@ using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Shapes;
+
+using Fluent.Collections;
 using Fluent.Extensions;
 using Fluent.Helpers;
 using Fluent.Internal;
@@ -295,6 +297,35 @@ public abstract class RibbonControl : Control, ICommandSource, IQuickAccessItemP
         Bind(source, element, InputControlProperties.InputMinWidthProperty, BindingMode.OneWay);
         Bind(source, element, InputControlProperties.InputWidthProperty, BindingMode.OneWay);
         Bind(source, element, InputControlProperties.InputHeightProperty, BindingMode.OneWay);
+
+        if (source is ItemsControl itemsControl && element is ItemsControl targetItemsControl)
+        {
+            Bind(source, element, nameof(ItemsControl.AlternationCount), ItemsControl.AlternationCountProperty, BindingMode.OneWay);
+
+            Bind(source, element, nameof(ItemsControl.DisplayMemberPath), ItemsControl.DisplayMemberPathProperty, BindingMode.OneWay);
+
+            Bind(source, element, nameof(ItemsControl.ItemBindingGroup), ItemsControl.ItemBindingGroupProperty, BindingMode.OneWay);
+            Bind(source, element, nameof(ItemsControl.ItemStringFormat), ItemsControl.ItemStringFormatProperty, BindingMode.OneWay);
+            Bind(source, element, nameof(ItemsControl.ItemTemplate), ItemsControl.ItemTemplateProperty, BindingMode.OneWay);
+            Bind(source, element, nameof(ItemsControl.ItemTemplateSelector), ItemsControl.ItemTemplateSelectorProperty, BindingMode.OneWay);
+
+            Bind(source, element, nameof(ItemsControl.ItemsPanel), ItemsControl.ItemsPanelProperty, BindingMode.OneWay);
+
+            Bind(source, element, nameof(ItemsControl.ItemContainerStyle), ItemsControl.ItemContainerStyleProperty, BindingMode.OneWay);
+            Bind(source, element, nameof(ItemsControl.ItemContainerStyleSelector), ItemsControl.ItemContainerStyleSelectorProperty, BindingMode.OneWay);
+
+            Bind(source, element, nameof(ItemsControl.GroupStyleSelector), ItemsControl.GroupStyleSelectorProperty, BindingMode.OneWay);
+
+            // cannot "bind" to GroupStyle observable collection property, but can at least keep them in sync
+            _ = new CollectionSyncHelper<GroupStyle>(itemsControl.GroupStyle, targetItemsControl.GroupStyle);
+
+            if (source is Selector && element is Selector)
+            {
+                Bind(source, element, nameof(Selector.SelectedValuePath), Selector.SelectedValuePathProperty, BindingMode.OneWay);
+
+                Bind(source, element, nameof(Selector.IsSynchronizedWithCurrentItem), Selector.IsSynchronizedWithCurrentItemProperty, BindingMode.OneWay);
+            }
+        }
 
         if (source is IHeaderedControl headeredControl)
         {


### PR DESCRIPTION
This is a general purpose fix for *all* possible missing QAT properties for `ItemsControl` & `Selector` based controls.

The quick access creation/binding logic seems quite fragmented in general.
A lot of logic happens in shared methods, then there are base class methods that bind some properties, omit others. Then there may be overloads that are extended COPIES of base implementations but that do not call the base versions.

All in all I'm not shocked that there are issues in there.

I _think_ at a minimum this could benefit from a cleanup where duplicated/repeated binds are eliminated and code is centralized.

---

To me the entire `IQuickAccessItemProvider.CreateQuickAccessItem()` logic smells like a poor man's attempt at templating/framework element factory replication. It knows how to create controls and set some linked states in them. But it does so in a fragmented, non-idiomatic and non-extensible way.

My gut instinct here is to say: That's fricken templating. Why not *implement* it as templating.

Every Fluent control that supports addition to QAT get's a 'QATTemplate' property of type `DataTemplate`. The QAT uses *that* as ItemTemplate per toolbar element. Each element's `DataContext` *is* the originating control. That should allow clean xaml based template definition & binding. Might need some custom Markupextension for some wiring (private event handlers in particular come to mind). Also there may be some shenanigans with logical child shuffling I'm not seeing clear enough.

But in general that would allow a cleaner XAML based (and thus idiomatic & extensible) approach to "What does this look like in the QAT"). Would allow reuse of (shared) styles for common properties and should allow way easier discovery of overlooked (or repeat used) links.


